### PR TITLE
fixed some clippy warnings

### DIFF
--- a/plugin/src/compiler.rs
+++ b/plugin/src/compiler.rs
@@ -272,12 +272,14 @@ fn compile_op(ecx: &ExtCtxt, buffer: &mut StmtBuffer, op: Ident, prefixes: Vec<I
             } else if op_size != Size::OWORD {
                 panic!("bad formatting data");
             }
-        } else if op_size == Size::WORD {
-            pref_size = true;
-        } else if op_size == Size::QWORD {
-            rex_w = true;
-        } else if op_size != Size::DWORD {
-            panic!("bad formatting data");
+        } else {
+            if op_size == Size::WORD {
+                pref_size = true;
+            } else if op_size == Size::QWORD {
+                rex_w = true;
+            } else if op_size != Size::DWORD {
+                panic!("bad formatting data");
+            }
         }
     }
 

--- a/plugin/src/lib.rs
+++ b/plugin/src/lib.rs
@@ -40,7 +40,7 @@ pub mod debug;
 #[plugin_registrar]
 pub fn registrar(reg: &mut Registry) {
     reg.register_syntax_extension(
-        intern("dynasm"), 
+        intern("dynasm"),
         SyntaxExtension::NormalTT(
             Box::new(main),
             None,
@@ -93,7 +93,7 @@ impl<'cx, 'a> MacResult for DynAsm<'cx, 'a> {
     }
 
     fn make_items(self: Box<Self>) -> Option<SmallVector<P<ast::Item>>> {
-        if self.stmts.len() == 0 {
+        if self.stmts.is_empty() {
             Some(SmallVector::zero())
         } else {
             None

--- a/plugin/src/parser.rs
+++ b/plugin/src/parser.rs
@@ -56,7 +56,7 @@ pub enum LabelType {
 #[derive(Debug)]
 pub enum JumpType {
     // note: these symbol choices try to avoid stuff that is a valid starting symbol for parse_expr
-    // in order to allow the full range of expressions to be used. the only currently existing ambiguity is 
+    // in order to allow the full range of expressions to be used. the only currently existing ambiguity is
     // with the symbol <, as this symbol is also the starting symbol for the universal calling syntax <Type as Trait>.method(args)
     Global(Ident),         // -> label
     Backward(Ident),       //  > label
@@ -285,7 +285,7 @@ impl RegId {
             _ => panic!("invalid register code")
         }
     }
-} 
+}
 
 impl Size {
     pub fn in_bytes(&self) -> u8 {
@@ -401,7 +401,7 @@ const SIZES:    [(&'static str, Size); 7] = [
     ("HWORD", Size::HWORD)
 ];
 fn eat_size_hint(parser: &mut Parser) -> Option<Size> {
-    for &(kw, size) in SIZES.iter() {
+    for &(kw, size) in &SIZES {
         if eat_pseudo_keyword(parser, kw) {
             return Some(size);
         }
@@ -427,11 +427,11 @@ fn parse_arg<'a>(ecx: &ExtCtxt, parser: &mut Parser<'a>) -> PResult<'a, Arg> {
     let start = parser.span;
 
     let in_bracket = parser.check(&token::OpenDelim(token::Bracket));
-    if in_bracket && parser.look_ahead(1, |x| match x {
-            &token::RArrow |
-            &token::Gt     |
-            &token::Lt     |
-            &token::FatArrow => true,
+    if in_bracket && parser.look_ahead(1, |x| match *x {
+            token::RArrow |
+            token::Gt     |
+            token::Lt     |
+            token::FatArrow => true,
             _ => false
         }) {
         parser.bump();
@@ -611,8 +611,8 @@ fn parse_arg<'a>(ecx: &ExtCtxt, parser: &mut Parser<'a>) -> PResult<'a, Arg> {
 }
 
 pub fn as_simple_name(expr: &ast::Expr) -> Option<Ident> {
-    let path = match expr {
-        &ast::Expr {node: ast::ExprKind::Path(None, ref path) , ..} => path,
+    let path = match *expr {
+        ast::Expr {node: ast::ExprKind::Path(None, ref path) , ..} => path,
         _ => return None
     };
 
@@ -691,7 +691,7 @@ fn parse_reg(ecx: &ExtCtxt, expr: &ast::Expr) -> Option<Spanned<Register>> {
                 let global_data = super::crate_local_data(ecx);
                 let lock = global_data.read();
                 if let Some(x) = lock.aliases.get(&path.node.name) {
-                    x.clone()
+                    *x
                 } else {
                     return None;
                 }
@@ -703,7 +703,7 @@ fn parse_reg(ecx: &ExtCtxt, expr: &ast::Expr) -> Option<Spanned<Register>> {
             span: path.span
         })
 
-    } else if let &ast::Expr {node: ast::ExprKind::Call(ref called, ref args), span, ..} = expr {
+    } else if let ast::Expr {node: ast::ExprKind::Call(ref called, ref args), span, ..} = *expr {
         // dynamically chosen registers
         if args.len() != 1 {
             return None;
@@ -720,7 +720,7 @@ fn parse_reg(ecx: &ExtCtxt, expr: &ast::Expr) -> Option<Spanned<Register>> {
             "Rh" => (Size::BYTE,  RegFamily::HIGHBYTE),
             "Rw" => (Size::WORD,  RegFamily::LEGACY),
             "Rd" => (Size::DWORD, RegFamily::LEGACY),
-            "Ra" => (Size::QWORD, RegFamily::LEGACY),
+            "Ra" |
             "Rq" => (Size::QWORD, RegFamily::LEGACY),
             "Rf" => (Size::PWORD, RegFamily::FP),
             "Rm" => (Size::QWORD, RegFamily::MMX),
@@ -799,7 +799,7 @@ fn parse_adds(ecx: &ExtCtxt, span: Span, expr: P<ast::Expr>) -> (Vec<(Register, 
     // reconstruct immediates
     let immediate = add_exprs(ecx, span, immediates.drain(..));
 
-    return (regs, immediate);
+    (regs, immediate)
 }
 
 fn collect_adds(ecx: &ExtCtxt, node: P<ast::Expr>, collection: &mut Vec<P<ast::Expr>>) {

--- a/plugin/src/x64data.rs
+++ b/plugin/src/x64data.rs
@@ -13,7 +13,7 @@ macro_rules! OpInner {
 }
 
 macro_rules! Ops {
-    ( $bind:ident; $( $name:tt $(| $more:tt)* = [ $( $( $e:expr ),+ ; )+ ] )* ) => { 
+    ( $bind:ident; $( $name:tt $(| $more:tt)* = [ $( $( $e:expr ),+ ; )+ ] )* ) => {
         lazy_static! {
             static ref $bind: HashMap<&'static str, &'static [Opdata]> = {
                 let mut map = HashMap::new();
@@ -32,7 +32,7 @@ macro_rules! Ops {
 }
 
 pub fn get_mnemnonic_data(name: &str) -> Option<&'static [Opdata]> {
-    return OPMAP.get(&name).map(|x| *x);
+    OPMAP.get(&name).map(|x| *x)
 }
 #[macro_use]
 pub mod flags {
@@ -771,7 +771,7 @@ Ops!(OPMAP;
 ] "fyl2xp1"     = [ b"",         [0xD9, 0xF9      ], X;
 ]
 // MMX instruction (also vol.   5) (note that 3DNow! instructions aren't supported)
-        
+
   "cvtpd2pi"    = [ b"xqwo",     [0x0F, 0x2D      ], X, PREF_66;
 ] "cvtpi2pd"    = [ b"youq",     [0x0F, 0x2A      ], X, PREF_66;
 ] "cvtpi2ps"    = [ b"youq",     [0x0F, 0x2A      ], X;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -109,7 +109,7 @@ pub struct Assembler {
     // label name -> target loc
     global_labels: HashMap<&'static str, usize>,
     // end of patch location -> name
-    global_relocs: Vec<(PatchLoc, &'static str)>, 
+    global_relocs: Vec<(PatchLoc, &'static str)>,
 
     // label id -> target loc
     dynamic_labels: Vec<Option<usize>>,
@@ -384,14 +384,14 @@ impl Assembler {
     }
 }
 
-/// A read-only lockable refernce to the internal ExecutableBuffer of an Assembler.
+/// A read-only lockable refernce to the internal `ExecutableBuffer` of an Assembler.
 /// To gain access to this buffer, it must be locked.
 impl Executor {
     /// Gain read-access to the internal `ExecutableBuffer`. While the returned guard
     /// is alive, it can be used to read and execute from the `ExecutableBuffer`.
     /// Any pointers created to the `Executablebuffer` should no longer be used when
     /// the guard is dropped.
-    pub fn lock<'a>(&'a self) -> RwLockReadGuard<'a, ExecutableBuffer> {
+    pub fn lock(&self) -> RwLockReadGuard<ExecutableBuffer> {
         self.execbuffer.read().unwrap()
     }
 }
@@ -403,9 +403,9 @@ impl ExecutableBuffer {
     /// will point to the start of the first instruction after the offset call,
     /// which can then be jumped or called to divert control flow into the executable
     /// buffer. Note that if this buffer is accessed through an Executor, these pointers
-    /// will only be valid as long as its lock is held. When no locks are held, 
+    /// will only be valid as long as its lock is held. When no locks are held,
     /// The assembler is free to relocate the executable buffer when it requires
-    /// more memory than available. 
+    /// more memory than available.
     pub fn ptr(&self, offset: AssemblyOffset) -> *const u8 {
         &self[offset.0] as *const u8
     }


### PR DESCRIPTION
Mostly about readability, but also removes a few needless `format!` and `vec!` calls, so it might even marginally improve performance. :smile: