### PR TITLE
vpsrld was missing a ENC_VM flag

### DIFF
--- a/plugin/src/x64data.rs
+++ b/plugin/src/x64data.rs
@@ -1445,7 +1445,7 @@ Ops!(OPMAP;
 ] "vpsraw"      = [ b"y*y*wo",   [   1, 0xE1      ], X, PREF_66 | AUTO_VEXL | VEX_OP;
                     b"y*y*ib",   [   1, 0x71      ], 4, PREF_66 | AUTO_VEXL | VEX_OP | ENC_VM;
 ] "vpsrld"      = [ b"y*y*wo",   [   1, 0xD2      ], X, PREF_66 | AUTO_VEXL | VEX_OP;
-                    b"y*y*ib",   [   1, 0x72      ], 2, PREF_66 | AUTO_VEXL | VEX_OP;
+                    b"y*y*ib",   [   1, 0x72      ], 2, PREF_66 | AUTO_VEXL | VEX_OP | ENC_VM;
 ] "psrldq"      = [ b"yoib",     [0x0F, 0x73      ], 3, PREF_66;
 ] "vpsrldq"     = [ b"y*y*ib",   [   1, 0x73      ], 3, PREF_66 | AUTO_VEXL | VEX_OP | ENC_VM;
 ] "vpsrlq"      = [ b"y*y*wo",   [   1, 0xD3      ], X, PREF_66 | AUTO_VEXL | VEX_OP;


### PR DESCRIPTION
I had a vpslld followed by a vpsrld generating the following machine code:

    32f:   c5 9d 72 f5 0c          vpslld ymm12,ymm5,0xc
    334:   c5 fd 72                (bad)
    337:   ed                      in     eax,dx
    338:   14 c4                   adc    al,0xc4
    33a:   c1 55 57 ec             rcl    DWORD PTR [rbp+0x57],0xec

Digging into your source, I saw the definition of vpsrld lacking `ENC_VM`, which the equivalent vpslld instruction had. I don't have a deep knowledge of what all these instruction definitions mean, but adding that flag fixed the generated code.

(The equivalent vpslld definition is

      "vpslld"      = [ b"y*y*wo",   [   1, 0xF2      ], X, PREF_66 | AUTO_VEXL | VEX_OP;
                        b"y*y*ib",   [   1, 0x72      ], 6, PREF_66 | AUTO_VEXL | VEX_OP | ENC_VM;

)