### PR TITLE
Make dynasm compile with rustc 1.28.0-nightly

### DIFF
--- a/plugin/src/lib.rs
+++ b/plugin/src/lib.rs
@@ -11,6 +11,7 @@ extern crate owning_ref;
 extern crate byteorder;
 
 use rustc_plugin::registry::Registry;
+use syntax::edition::DEFAULT_EDITION;
 use syntax::ext::base::{SyntaxExtension, ExtCtxt, MacResult, DummyResult};
 use syntax::ext::build::AstBuilder;
 use syntax::codemap::{Span, Spanned};
@@ -46,7 +47,8 @@ pub fn registrar(reg: &mut Registry) {
                                       def_info: None,
                                       unstable_feature: None,
                                       allow_internal_unstable: false,
-                                      allow_internal_unsafe: false
+                                      allow_internal_unsafe: false,
+                                      edition: DEFAULT_EDITION
                                   });
 
     #[cfg(feature = "dynasm_opmap")]
@@ -56,7 +58,8 @@ pub fn registrar(reg: &mut Registry) {
                                       def_info: None,
                                       unstable_feature: None,
                                       allow_internal_unstable: false,
-                                      allow_internal_unsafe: false
+                                      allow_internal_unsafe: false,
+                                      edition: DEFAULT_EDITION
                                   });
 }
 


### PR DESCRIPTION
This passes an Edition (DEFAULT_EDITION) to the SyntaxExtension::NormalTT constructor, as it now requires one.

This makes dynasm compile with more recently rustc nightlies such as
rustc 1.28.0-nightly (a3085756e 2018-05-19).