### PR TITLE
Get it building on the latest nightly.

### DIFF
--- a/plugin/src/arch/x64/parser.rs
+++ b/plugin/src/arch/x64/parser.rs
@@ -291,7 +291,7 @@ pub fn as_simple_name(expr: &ast::Expr) -> Option<Ident> {
     }
 
     let segment = &path.segments[0];
-    if !segment.parameters.is_none() {
+    if !segment.args.is_none() {
         return None;
     }
 

--- a/plugin/src/arch/x64/parser.rs
+++ b/plugin/src/arch/x64/parser.rs
@@ -40,7 +40,7 @@ pub fn parse_instruction<'a>(ctx: &mut Context, ecx: &ExtCtxt, parser: &mut Pars
     // parse (sizehint? expr),*
     let mut args = Vec::new();
 
-    if !parser.check(&token::Semi) && !parser.check(&token::Eof) {
+    if !parser.look_ahead(0, |x| x == &token::Semi || x == &token::Eof) {
         args.push(parse_arg(ctx, ecx, parser)?);
 
         while parser.eat(&token::Comma) {
@@ -132,7 +132,7 @@ fn parse_arg<'a>(ctx: &mut Context, ecx: &ExtCtxt, parser: &mut Parser<'a>) -> P
 
     let start = parser.span;
 
-    let in_bracket = parser.check(&token::OpenDelim(token::Bracket));
+    let in_bracket = parser.look_ahead(0, |x| x == &token::OpenDelim(token::Bracket));
     if in_bracket && parser.look_ahead(1, |x| match *x {
             token::RArrow |
             token::Gt     |

--- a/plugin/src/directive.rs
+++ b/plugin/src/directive.rs
@@ -78,7 +78,7 @@ impl DynasmData {
             d => {
                 // unknown directive. skip ahead until we hit a ; so the parser can recover
                 ecx.span_err(parser.span, &format!("unknown directive '{}'", d));
-                while !(parser.check(&token::Semi) && parser.check(&token::Eof)) {
+                while !parser.look_ahead(0, |x| x == &token::Semi || x == &token::Eof) {
                     parser.bump();
                 }
             }
@@ -88,7 +88,7 @@ impl DynasmData {
     }
 
     fn directive_const<'b>(stmts: &mut Vec<Stmt>, parser: &mut Parser<'b>, size: Size) -> PResult<'b, ()> {
-        if !parser.check(&token::Semi) && !parser.check(&token::Eof) {
+        if !parser.look_ahead(0, |x| x == &token::Semi || x == &token::Eof) {
             stmts.push(Stmt::ExprSigned(parser.parse_expr()?, size));
 
             while parser.eat(&token::Comma) {

--- a/plugin/src/lib.rs
+++ b/plugin/src/lib.rs
@@ -188,7 +188,7 @@ fn compile<'a>(ecx: &mut ExtCtxt, parser: &mut Parser<'a>) -> PResult<'a, Vec<as
 
     let mut stmts = Vec::new();
 
-    while !parser.check(&token::Eof) {
+    while !parser.look_ahead(0, |x| x == &token::Eof) {
         parser.expect(&token::Semi)?;
 
         // ;; stmt

--- a/plugin/src/lib.rs
+++ b/plugin/src/lib.rs
@@ -48,7 +48,8 @@ pub fn registrar(reg: &mut Registry) {
                                       unstable_feature: None,
                                       allow_internal_unstable: false,
                                       allow_internal_unsafe: false,
-                                      edition: DEFAULT_EDITION
+                                      edition: DEFAULT_EDITION,
+                                      local_inner_macros: false,
                                   });
 
     #[cfg(feature = "dynasm_opmap")]
@@ -59,7 +60,8 @@ pub fn registrar(reg: &mut Registry) {
                                       unstable_feature: None,
                                       allow_internal_unstable: false,
                                       allow_internal_unsafe: false,
-                                      edition: DEFAULT_EDITION
+                                      edition: DEFAULT_EDITION,
+                                      local_inner_macros: false,
                                   });
 }
 

--- a/plugin/src/serialize.rs
+++ b/plugin/src/serialize.rs
@@ -353,7 +353,7 @@ pub fn expr_size_of(ecx: &ExtCtxt, path: ast::Path) -> P<ast::Expr> {
 
     let ty = ecx.ty_path(path);
     let idents = ["std", "mem", "size_of"].iter().cloned().map(ast::Ident::from_str).collect();
-    let size_of = ecx.path_all(span, true, idents, Vec::new(), vec![ty], Vec::new());
+    let size_of = ecx.path_all(span, true, idents, vec![ast::GenericArg::Type(ty)], Vec::new());
     ecx.expr_call(span, ecx.expr_path(size_of), Vec::new())
 }
 


### PR DESCRIPTION
I don't know if replacing `Parser::check` with `Parser::look_ahead` is the right thing to do, though. Closes #34.

```
rustc 1.29.0-nightly (12ed235ad 2018-07-18)
```