### PR TITLE
Allow `fn alter` to return a type

### DIFF
--- a/runtime/src/x86.rs
+++ b/runtime/src/x86.rs
@@ -133,13 +133,18 @@ impl Assembler {
     /// Using this `AssemblyModifier` changes can be made to the committed code.
     /// After this function returns, any labels in these changes will be resolved
     /// and the `ExecutableBuffer` will be unlocked again.
-    pub fn alter<F>(&mut self, f: F) where F: FnOnce(&mut AssemblyModifier) -> () {
+    pub fn alter<F, O>(&mut self, f: F) -> O
+    where
+        F: FnOnce(&mut AssemblyModifier) -> O
+    {
         self.commit();
 
         let cloned = self.base.reader();
         let mut lock = cloned.write().unwrap();
+        let mut out = None;
 
         // move the buffer out of the assembler for a bit
+        // no commit is required afterwards as we directly modified the buffer.
         take_mut::take_or_recover(&mut *lock, || ExecutableBuffer::new(0, MMAP_INIT_SIZE).unwrap(), |buf| {
             let mut buf = buf.make_mut().unwrap();
 
@@ -151,7 +156,7 @@ impl Assembler {
                     last_asmoffset: 0,
                     new_managed_relocs: Vec::new(),
                 };
-                f(&mut m);
+                out = Some(f(&mut m));
                 m.encode_relocs();
             }
 
@@ -159,7 +164,7 @@ impl Assembler {
             buf.make_exec().unwrap()
         });
 
-        // no commit is required as we directly modified the buffer.
+        out.expect("Programmer error: `take_or_recover` didn't initialize `out`. This is a bug!")
     }
 
     /// Similar to `Assembler::alter`, this method allows modification of the yet to be


### PR DESCRIPTION
This improves error handling for these functions - you can return a `Result<(), Error>` if the inner function fails. Ideally there would be a way to do this in `take_mut` so you didn't need to use an `Option`, but since `take_mut::take_or_recover` is generic it can probably be inlined and the `expect` failure branch can probably be optimised out. A possible optimisation is to unsafely synthesise for ZSTs so that the `Fn(...) -> ()` case can generate code precisely equal to the code before this PR.