### PR TITLE
Move to proc-macro-error, ditching proc_macro_diagnostic

### DIFF
--- a/plugin/Cargo.toml
+++ b/plugin/Cargo.toml
@@ -23,6 +23,7 @@ bitflags = "1"
 owning_ref = "^0.4"
 byteorder = "1"
 quote = "1"
+proc-macro-error = "0.4"
 
 [dependencies.syn]
 version = "1"

--- a/plugin/Cargo.toml
+++ b/plugin/Cargo.toml
@@ -23,7 +23,7 @@ bitflags = "1"
 owning_ref = "^0.4"
 byteorder = "1"
 quote = "1"
-proc-macro-error = "0.4"
+proc-macro-error = "1"
 
 [dependencies.syn]
 version = "1"

--- a/plugin/src/arch/aarch64/mod.rs
+++ b/plugin/src/arch/aarch64/mod.rs
@@ -1,4 +1,5 @@
 use syn::parse;
+use proc_macro_error::emit_error;
 
 mod ast;
 mod parser;
@@ -9,7 +10,7 @@ mod encoding_helpers;
 mod debug;
 
 use crate::State;
-use crate::common::{Size, Stmt, Jump, emit_error_at};
+use crate::common::{Size, Stmt, Jump};
 use crate::arch::Arch;
 use self::aarch64data::Relocation;
 
@@ -40,7 +41,7 @@ impl Arch for ArchAarch64 {
 
     fn set_features(&mut self, features: &[syn::Ident]) {
         if let Some(feature) = features.first() {
-            emit_error_at(feature.span(), "Arch aarch64 has no known features".into());
+            emit_error!(feature, "Arch aarch64 has no known features");
         }
     }
 
@@ -53,7 +54,7 @@ impl Arch for ArchAarch64 {
             Size::DWORD => Relocation::LITERAL32,
             Size::QWORD => Relocation::LITERAL64,
             _ => {
-                emit_error_at(span, "Relocation of unsupported size for the current target architecture".into());
+                emit_error!(span, "Relocation of unsupported size for the current target architecture");
                 return;
             }
         };
@@ -78,7 +79,7 @@ impl Arch for ArchAarch64 {
         let match_data = match matching::match_instruction(&mut ctx, &instruction, args) {
             Err(None) => return Ok(()),
             Err(Some(e)) => {
-                emit_error_at(span, e);
+                emit_error!(span, e);
                 return Ok(())
             }
             Ok(m) => m
@@ -87,7 +88,7 @@ impl Arch for ArchAarch64 {
         match compiler::compile_instruction(&mut ctx, match_data) {
             Err(None) => return Ok(()),
             Err(Some(e)) => {
-                emit_error_at(span, e);
+                emit_error!(span, e);
                 return Ok(())
             }
             Ok(()) => ()

--- a/plugin/src/arch/mod.rs
+++ b/plugin/src/arch/mod.rs
@@ -1,6 +1,7 @@
 use syn::parse;
+use proc_macro_error::emit_error;
 
-use crate::common::{Size, Stmt, Jump, emit_error_at};
+use crate::common::{Size, Stmt, Jump};
 use crate::State;
 
 use std::fmt::Debug;
@@ -34,13 +35,13 @@ impl Arch for DummyArch {
 
     fn set_features(&mut self, features: &[syn::Ident]) {
         if let Some(feature) = features.first() {
-            emit_error_at(feature.span(), "Cannot set features when the assembling architecture is undefined. Define it using a .arch directive".into());
+            emit_error!(feature, "Cannot set features when the assembling architecture is undefined. Define it using a .arch directive");
         }
     }
 
     fn handle_static_reloc(&self, _stmts: &mut Vec<Stmt>, reloc: Jump, _size: Size) {
         let span = reloc.span();
-        emit_error_at(span, "Current assembling architecture is undefined. Define it using a .arch directive".into());
+        emit_error!(span, "Current assembling architecture is undefined. Define it using a .arch directive");
     }
 
     fn default_align(&self) -> u8 {
@@ -48,7 +49,7 @@ impl Arch for DummyArch {
     }
 
     fn compile_instruction(&self, _state: &mut State, input: parse::ParseStream) -> parse::Result<()> {
-        emit_error_at(input.cursor().span(), "Current assembling architecture is undefined. Define it using a .arch directive".into());
+        emit_error!(input.cursor().span(), "Current assembling architecture is undefined. Define it using a .arch directive");
         Ok(())
     }
 }

--- a/plugin/src/arch/x64/mod.rs
+++ b/plugin/src/arch/x64/mod.rs
@@ -1,4 +1,5 @@
 use syn::parse;
+use proc_macro_error::emit_error;
 
 mod ast;
 mod compiler;
@@ -8,7 +9,7 @@ mod x64data;
 
 use crate::State;
 use crate::arch::Arch;
-use crate::common::{Size, Stmt, Jump, emit_error_at};
+use crate::common::{Size, Stmt, Jump};
 
 #[cfg(feature = "dynasm_opmap")]
 pub use debug::create_opmap;
@@ -47,7 +48,7 @@ impl Arch for Archx64 {
             new_features |= match x64data::Features::from_str(&ident.to_string()) {
                 Some(feature) => feature,
                 None => {
-                    emit_error_at(ident.span(), format!("Architecture x64 does not support feature '{}'", ident.to_string()));
+                    emit_error!(ident, "Architecture x64 does not support feature '{}'", ident);
                     continue;
                 }
             }
@@ -76,7 +77,7 @@ impl Arch for Archx64 {
         let span = instruction.span;
 
         if let Err(Some(e)) = compiler::compile_instruction(&mut ctx, instruction, args) {
-            emit_error_at(span, e);
+            emit_error!(span, e);
         }
         Ok(())
     }
@@ -104,7 +105,7 @@ impl Arch for Archx86 {
             new_features |= match x64data::Features::from_str(&ident.to_string()) {
                 Some(feature) => feature,
                 None => {
-                    emit_error_at(ident.span(), format!("Architecture x86 does not support feature '{}'", ident.to_string()));
+                    emit_error!(ident, "Architecture x86 does not support feature '{}'", ident);
                     continue;
                 }
             }
@@ -133,7 +134,7 @@ impl Arch for Archx86 {
         let span = instruction.span;
 
         if let Err(Some(e)) = compiler::compile_instruction(&mut ctx, instruction, args) {
-            emit_error_at(span, e);
+            emit_error!(span, e);
         }
         Ok(())
     }

--- a/plugin/src/arch/x64/parser.rs
+++ b/plugin/src/arch/x64/parser.rs
@@ -1,10 +1,11 @@
 use syn::{parse, Token};
 use syn::spanned::Spanned;
 use proc_macro2::Span;
+use proc_macro_error::emit_error;
 
 use lazy_static::lazy_static;
 
-use crate::common::{Size, emit_error_at};
+use crate::common::Size;
 use crate::parse_helpers::{eat_pseudo_keyword, parse_ident_or_rust_keyword, as_ident, ParseOptExt};
 
 use super::{Context, X86Mode};
@@ -134,7 +135,7 @@ fn parse_arg(ctx: &mut Context, input: parse::ParseStream) -> parse::Result<RawA
             })
         }
 
-        // memory reference 
+        // memory reference
         let nosplit = eat_pseudo_keyword(inner, "NOSPLIT");
         let disp_size = eat_size_hint(ctx, inner);
         let expr: syn::Expr = inner.parse()?;
@@ -162,7 +163,7 @@ fn parse_arg(ctx: &mut Context, input: parse::ParseStream) -> parse::Result<RawA
         let base = if let Some((_, base)) = parse_reg(ctx, &arg) {
             base
         } else {
-            emit_error_at(arg.span(), "Expected register".into());
+            emit_error!(arg, "Expected register");
             return Ok(RawArg::Invalid);
         };
 
@@ -208,7 +209,7 @@ fn parse_arg(ctx: &mut Context, input: parse::ParseStream) -> parse::Result<RawA
     // direct register
     if let Some((span, reg)) = parse_reg(ctx, &arg) {
         if size.is_some() {
-            emit_error_at(span, "size hint with direct register".into());
+            emit_error!(span, "size hint with direct register");
         }
         return Ok(RawArg::Direct {
             reg,

--- a/plugin/src/common.rs
+++ b/plugin/src/common.rs
@@ -93,7 +93,7 @@ impl ParseOpt for Jump {
             let name: syn::Ident = input.parse()?;
 
             JumpKind::Backward(name)
-            
+
         // => dynamic_label
         } else if input.peek(Token![=>]) {
             let _: Token![=>] = input.parse()?;
@@ -236,15 +236,6 @@ pub fn delimited<T: ToTokens>(expr: T) -> TokenTree {
     );
     group.set_span(span);
     proc_macro2::TokenTree::Group(group)
-}
-
-
-
-// FIXME: temporary till Diagnostic gets stabilized
-/// Emit a diagnostic at a certain span.
-pub fn emit_error_at(span: Span, msg: String) {
-    let span: proc_macro::Span = span.unstable();
-    span.error(msg).emit();
 }
 
 

--- a/plugin/src/lib.rs
+++ b/plugin/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(proc_macro_diagnostic)]
 #![feature(proc_macro_span)]
 
 // token/ast manipulation
@@ -17,6 +16,7 @@ use syn::parse;
 use syn::{Token, parse_macro_input};
 use proc_macro2::{Span, TokenTree, TokenStream};
 use quote::quote;
+use proc_macro_error::proc_macro_error;
 
 use lazy_static::lazy_static;
 use owning_ref::{OwningRef, RwLockReadGuardRef};
@@ -38,6 +38,7 @@ mod parse_helpers;
 
 /// The whole point
 #[proc_macro]
+#[proc_macro_error]
 pub fn dynasm(tokens: proc_macro::TokenStream) -> proc_macro::TokenStream {
     // try parsing the tokenstream into a dynasm struct containing
     // an abstract representation of the statements to create

--- a/runtime/src/aarch64.rs
+++ b/runtime/src/aarch64.rs
@@ -42,7 +42,7 @@ impl Aarch64Relocation {
                     return Err(ImpossibleRelocation { } );
                 }
                 let value = (value >> 2) as u32;
-                (value & 0x3FF_FFFF)
+                value & 0x3FF_FFFF
             },
             Self::BCOND => {
                 if value & 3 != 0 || !fits_signed_bitfield(value >> 2, 19) {

--- a/runtime/src/relocations.rs
+++ b/runtime/src/relocations.rs
@@ -145,5 +145,5 @@ pub(crate) fn fits_signed_bitfield(value: i64, bits: u8) -> bool {
     }
 
     let half = 1i64 << (bits - 1);
-    (value < half && value >= -half)
+    value < half && value >= -half
 }


### PR DESCRIPTION
Some work on #31 

This PR replaces the hand-made `emit_error_at` function with `emit_error!` macro from `proc-macro-error`, thus getting rid of `#![feature(proc_macro_diagnostic)]`. One step closer to stable!

I didn't check how the errors would look like here, but we've been using it in `structopt` for half a year now, and it works like charm.