### PR TITLE
Expose register names to the runtime.

### DIFF
--- a/runtime/src/aarch64.rs
+++ b/runtime/src/aarch64.rs
@@ -1,5 +1,6 @@
 //! This module implements the relocation model for the aarch64 architecture, as well as aliases for aarch64 Assemblers.
 
+use crate::Register;
 use crate::relocations::{Relocation, RelocationSize, RelocationKind, ImpossibleRelocation, fits_signed_bitfield};
 use byteorder::{ByteOrder, LittleEndian};
 use std::convert::TryFrom;
@@ -235,5 +236,67 @@ pub fn encode_floating_point_immediate(value: f32) -> Option<u8> {
         Some((((bits >> 24) & 0x80) | ((bits >> 19) & 0x7F)) as u8)
     } else {
         None
+    }
+}
+
+/// General purpose registers. 4 or 8 bytes.
+#[allow(missing_docs)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum RX {
+    X0 = 0x00, X1 = 0x01, X2 = 0x02, X3 = 0x03,
+    X4 = 0x04, X5 = 0x05, X6 = 0x06, X7 = 0x07,
+    X8 = 0x08, X9 = 0x09, X10= 0x0A, X11= 0x0B,
+    X12= 0x0C, X13= 0x0D, X14= 0x0E, X15= 0x0F,
+    X16= 0x10, X17= 0x11, X18= 0x12, X19= 0x13,
+    X20= 0x14, X21= 0x15, X22= 0x16, X23= 0x17,
+    X24= 0x18, X25= 0x19, X26= 0x1A, X27= 0x1B,
+    X28= 0x1C, X29= 0x1D, X30= 0x1E, XZR= 0x1F,
+}
+reg_impls!(RX);
+
+/// 0x1F addresses both XZR and SP (disambiguated by context). This enum is a mirror of RX just
+/// with the SP in place of XZR.
+#[allow(missing_docs)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum RXSP {
+    X0 = 0x00, X1 = 0x01, X2 = 0x02, X3 = 0x03,
+    X4 = 0x04, X5 = 0x05, X6 = 0x06, X7 = 0x07,
+    X8 = 0x08, X9 = 0x09, X10= 0x0A, X11= 0x0B,
+    X12= 0x0C, X13= 0x0D, X14= 0x0E, X15= 0x0F,
+    X16= 0x10, X17= 0x11, X18= 0x12, X19= 0x13,
+    X20= 0x14, X21= 0x15, X22= 0x16, X23= 0x17,
+    X24= 0x18, X25= 0x19, X26= 0x1A, X27= 0x1B,
+    X28= 0x1C, X29= 0x1D, X30= 0x1E, SP = 0x1F,
+}
+reg_impls!(RXSP);
+
+/// Scalar FP / vector SIMD registers. 1, 2, 4, 8 or 16-bytes.
+#[allow(missing_docs)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum RV {
+    V0 = 0x00, V1 = 0x01, V2 = 0x02, V3 = 0x03,
+    V4 = 0x04, V5 = 0x05, V6 = 0x06, V7 = 0x07,
+    V8 = 0x08, V9 = 0x09, V10= 0x0A, V11= 0x0B,
+    V12= 0x0C, V13= 0x0D, V14= 0x0E, V15= 0x0F,
+    V16= 0x10, V17= 0x11, V18= 0x12, V19= 0x13,
+    V20= 0x14, V21= 0x15, V22= 0x16, V23= 0x17,
+    V24= 0x18, V25= 0x19, V26= 0x1A, V27= 0x1B,
+    V28= 0x1C, V29= 0x1D, V30= 0x1E, V31= 0x1F,
+}
+reg_impls!(RV);
+
+#[cfg(test)]
+mod tests {
+    use super::RX::*;
+    use crate::Register;
+
+    #[test]
+    fn reg_code() {
+        assert_eq!(X2.code(), 2);
+    }
+
+    #[test]
+    fn reg_code_from() {
+        assert_eq!(u8::from(X24), 0x18);
     }
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -7,6 +7,24 @@
 pub mod mmap;
 pub mod components;
 pub mod relocations;
+
+/// Helper to implement common traits on register enums.
+macro_rules! reg_impls {
+    ($r:ty) => {
+        impl $crate::Register for $r {
+            fn code(&self) -> u8 {
+                *self as u8
+            }
+        }
+
+        impl From<$r> for u8 {
+            fn from(rq: $r) -> u8 {
+                rq.code()
+            }
+        }
+    }
+}
+
 pub mod x64;
 pub mod x86;
 pub mod aarch64;
@@ -15,11 +33,12 @@ pub use crate::mmap::ExecutableBuffer;
 use crate::components::{MemoryManager, LabelRegistry, RelocRegistry, ManagedRelocs, PatchLoc};
 use crate::relocations::Relocation;
 
+use std::hash::Hash;
 use std::iter::Extend;
 use std::sync::{Arc, RwLock, RwLockReadGuard};
 use std::io;
 use std::error;
-use std::fmt;
+use std::fmt::{self, Debug};
 use std::mem;
 
 /// This macro takes a *const pointer from the source operand, and then casts it to the desired return type.
@@ -1016,4 +1035,10 @@ impl<'a, 'b> Extend<&'b u8> for UncommittedModifier<'a> {
     fn extend<T>(&mut self, iter: T) where T: IntoIterator<Item=&'b u8> {
         self.extend(iter.into_iter().cloned())
     }
+}
+
+/// All register enumerations implement this.
+pub trait Register: Debug + Clone + Copy + PartialEq + Eq + Hash {
+    /// Returns the integer ID of the register.
+    fn code(&self) -> u8;
 }

--- a/runtime/src/x64.rs
+++ b/runtime/src/x64.rs
@@ -1,6 +1,9 @@
 //! This module implements the relocation model for the x64 architecture, as well as aliases for x64 Assemblers.
 
 use crate::relocations::{Relocation, RelocationSize, RelocationKind, ImpossibleRelocation};
+use crate::Register;
+
+use std::hash::Hash;
 
 
 /// Relocation implementation for the x64 architecture.
@@ -56,3 +59,63 @@ pub type Assembler = crate::Assembler<X64Relocation>;
 pub type AssemblyModifier<'a> = crate::Modifier<'a, X64Relocation>;
 /// An x64 UncommittedModifier. This is aliased here for backwards compatability.
 pub type UncommittedModifier<'a> = crate::UncommittedModifier<'a>;
+
+/// 8-byte general purpose "quad-word" registers.
+///
+/// RIP does not appear here as it is addressed differently in dynasm.
+#[allow(missing_docs)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Rq {
+    RAX = 0x0, RCX = 0x1, RDX = 0x2, RBX = 0x3,
+    RSP = 0x4, RBP = 0x5, RSI = 0x6, RDI = 0x7,
+    R8  = 0x8, R9  = 0x9, R10 = 0xA, R11 = 0xB,
+    R12 = 0xC, R13 = 0xD, R14 = 0xE, R15 = 0xF,
+}
+reg_impls!(Rq);
+
+
+/// 16-byte SSE registers.
+///
+/// Note that XMM8-SMM15 are X86_64 specific, so we don't inherit this from the enum of the same
+/// name in the X86 backend.
+#[allow(missing_docs)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Rx {
+    XMM0  = 0x0, XMM1  = 0x1, XMM2  = 0x2, XMM3  = 0x3,
+    XMM4  = 0x4, XMM5  = 0x5, XMM6  = 0x6, XMM7  = 0x7,
+    XMM8  = 0x8, XMM9  = 0x9, XMM10 = 0xA, XMM11 = 0xB,
+    XMM12 = 0xC, XMM13 = 0xD, XMM14 = 0xE, XMM15 = 0xF,
+}
+reg_impls!(Rx);
+
+/// 8-byte control registers.
+///
+/// Note that 32-bit x86 can only address CR0-7, hence this enum is duplicated here.
+#[allow(missing_docs)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum RC {
+    CR0  = 0x0, CR1  = 0x1, CR2  = 0x2, CR3  = 0x3,
+    CR4  = 0x4, CR5  = 0x5, CR6  = 0x6, CR7  = 0x7,
+    CR8  = 0x8, CR9  = 0x9, CR10 = 0xA, CR11 = 0xB,
+    CR12 = 0xC, CR13 = 0xD, CR14 = 0xE, CR15 = 0xF,
+}
+reg_impls!(RC);
+
+// The other register families are the same as 32-bit X86.
+pub use crate::x86::{Rh, Rf, Rm, Rs, RD, RB};
+
+#[cfg(test)]
+mod tests {
+    use super::Rq::*;
+    use crate::Register;
+
+    #[test]
+    fn reg_code() {
+        assert_eq!(RAX.code(), 0);
+    }
+
+    #[test]
+    fn reg_code_from() {
+        assert_eq!(u8::from(R11), 11);
+    }
+}

--- a/runtime/src/x86.rs
+++ b/runtime/src/x86.rs
@@ -1,5 +1,6 @@
 //! This module implements the relocation model for the x86 architecture, as well as aliases for x68 Assemblers.
 
+use crate::Register;
 use crate::relocations::{Relocation, RelocationSize, RelocationKind, ImpossibleRelocation};
 
 
@@ -60,3 +61,103 @@ pub type Assembler = crate::Assembler<X86Relocation>;
 pub type AssemblyModifier<'a> = crate::Modifier<'a, X86Relocation>;
 /// An x86 UncommittedModifier. This is aliased here for backwards compatability.
 pub type UncommittedModifier<'a> = crate::UncommittedModifier<'a>;
+
+
+/// 4-byte general purpose "double-word" registers.
+///
+/// EIP does not appear here as it is addressed differently in dynasm.
+#[allow(missing_docs)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Rd {
+    EAX = 0x00, ECX = 0x01, EDX = 0x02, EBX = 0x03,
+    ESP = 0x04, EBP = 0x05, ESI = 0x06, EDI = 0x07,
+}
+reg_impls!(Rd);
+
+/// High-byte general purpose registers.
+#[allow(missing_docs)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Rh {
+    AH = 0x4, CH = 0x5, DH = 0x6, BH = 0x7,
+}
+reg_impls!(Rh);
+
+/// 10-byte floating point registers.
+#[allow(missing_docs)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Rf {
+    ST0 = 0x0, ST1 = 0x1, ST2 = 0x2, ST3 = 0x3,
+    ST4 = 0x4, ST5 = 0x5, ST6 = 0x6, ST7 = 0x7,
+}
+reg_impls!(Rf);
+
+/// 8-byte MMX registers. Alternative encoding exists.
+#[allow(missing_docs)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Rm {
+    MMX0 = 0x0, MMX1 = 0x1, MMX2 = 0x2, MMX3 = 0x3,
+    MMX4 = 0x4, MMX5 = 0x5, MMX6 = 0x6, MMX7 = 0x7,
+}
+reg_impls!(Rm);
+
+/// 16-byte SSE registers.
+#[allow(missing_docs)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Rx {
+    XMM0  = 0x0, XMM1  = 0x1, XMM2  = 0x2, XMM3  = 0x3,
+    XMM4  = 0x4, XMM5  = 0x5, XMM6  = 0x6, XMM7  = 0x7,
+}
+reg_impls!(Rx);
+
+/// 2-byte segment registers.
+#[allow(missing_docs)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Rs {
+    ES = 0x0, CS = 0x1, SS = 0x2, DS = 0x3,
+    FS = 0x4, GS = 0x5,
+}
+reg_impls!(Rs);
+
+/// 4-byte control registers.
+#[allow(missing_docs)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum RC {
+    CR0  = 0x0, CR1  = 0x1, CR2  = 0x2, CR3  = 0x3,
+    CR4  = 0x4, CR5  = 0x5, CR6  = 0x6, CR7  = 0x7,
+}
+reg_impls!(RC);
+
+/// 4-byte debug registers.
+#[allow(missing_docs)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum RD {
+    DR0  = 0x0, DR1  = 0x1, DR2  = 0x2, DR3  = 0x3,
+    DR4  = 0x4, DR5  = 0x5, DR6  = 0x6, DR7  = 0x7,
+    DR8  = 0x8, DR9  = 0x9, DR10 = 0xA, DR11 = 0xB,
+    DR12 = 0xC, DR13 = 0xD, DR14 = 0xE, DR15 = 0xF,
+}
+reg_impls!(RD);
+
+/// 16-byte bound registers.
+#[allow(missing_docs)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum RB {
+    BND0 = 0x0, BND1 = 0x1, BND2 = 0x2, BND3 = 0x3
+}
+reg_impls!(RB);
+
+#[cfg(test)]
+mod tests {
+    use super::Rd::*;
+    use crate::Register;
+
+    #[test]
+    fn reg_code() {
+        assert_eq!(EAX.code(), 0);
+    }
+
+    #[test]
+    fn reg_code_from() {
+        assert_eq!(u8::from(ECX), 1);
+    }
+}

--- a/runtime/src/x86.rs
+++ b/runtime/src/x86.rs
@@ -1,4 +1,4 @@
-//! This module implements the relocation model for the x86 architecture, as well as aliases for x68 Assemblers.
+//! This module implements the relocation model for the x86 architecture, as well as aliases for x86 Assemblers.
 
 use crate::Register;
 use crate::relocations::{Relocation, RelocationSize, RelocationKind, ImpossibleRelocation};


### PR DESCRIPTION
Hi,

First, thanks for dynasm-rs. We are using it as part of an experimental JIT compiler!

I've noticed that when I'm developing using dynasm-rs, I spend a considerable amount of time looking up register numbers, and the other day I had a bug where I had used the wrong register number.

Would you be open to exposing symbolic names for registers in the runtime, so that users don't have to look up the register numbers?

This draft PR shows one possible way to do this. I've also added a `Reg!` macro which allows the user to get the register number for the current system more concisely.

So instead of:
```
x64::RegId::RAX as u8
```

We can do
```
Reg!(RAX)
```

For now I've only implemented it for X86_64, but if we agree on an API, I'm happy to do the others too (and update the docs).

Do you expect users to be able to cross-assemble with dynasm-rs? This might impact our design choices.

What do you think?

Thanks!