### PR TITLE
Added ud1 opcode to X64

### DIFF
--- a/plugin/src/arch/x64/gen_opmap.rs
+++ b/plugin/src/arch/x64/gen_opmap.rs
@@ -2623,6 +2623,9 @@ Ops!(
     b"yomd"       , [0x0F, 0x2E        ], X, DEFAULT, SSE;
     b"yoyo"       , [0x0F, 0x2E        ], X, DEFAULT, SSE;
 ]
+"ud1" = [
+    b"rdvd"       , [0x0F, 0xB9        ], X, EXACT_SIZE;
+]
 "ud2" = [
     b""           , [0x0F, 0x0B        ], X;
 ]


### PR DESCRIPTION
Adding ud1 opcode, that is "undefined opcode", but with a r/m mod operator. This is to allow some "payload" in the Undefined opcode (by grabbing the bytes at the SIGILL location)