### PR TITLE
Allow reserving space in various Vec and HashMaps for performance

### DIFF
--- a/runtime/src/components.rs
+++ b/runtime/src/components.rs
@@ -148,6 +148,21 @@ impl LabelRegistry {
         }
     }
 
+    /// Reserve capacity for at least `additional` more global labels to be inserted
+    pub fn reserve_global(&mut self, additional: usize) {
+        self.global_labels.reserve(additional);
+    }
+
+    /// Reserve capacity for at least `additional` more dynamic labels to be inserted
+    pub fn reserve_dynamic(&mut self, additional: usize) {
+        self.dynamic_labels.reserve(additional);
+    }
+
+    /// Reserve capacity for at least `additional` more local labels to be inserted
+    pub fn reserve_local(&mut self, additional: usize) {
+        self.local_labels.reserve(additional);
+    }
+
     /// Create a new dynamic label id
     pub fn new_dynamic_label(&mut self) -> DynamicLabel {
         let id = self.dynamic_labels.len();
@@ -291,6 +306,21 @@ impl<R: Relocation> RelocRegistry<R> {
             dynamic: Vec::new(),
             local: HashMap::new()
         }
+    }
+
+    /// Reserve capacity for at least `additional` more global relocs to be inserted
+    pub fn reserve_global(&mut self, additional: usize) {
+        self.global.reserve(additional);
+    }
+
+    /// Reserve capacity for at least `additional` more dynamic relocs to be inserted
+    pub fn reserve_dynamic(&mut self, additional: usize) {
+        self.dynamic.reserve(additional);
+    }
+
+    /// Reserve capacity for at least `additional` more local relocs to be inserted
+    pub fn reserve_local(&mut self, additional: usize) {
+        self.local.reserve(additional);
     }
 
     /// Add a new patch targetting the global label `name`.

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -363,6 +363,11 @@ impl<R: Relocation> VecAssembler<R> {
         }
     }
 
+    /// Reserve capacity for at least `additional` more instruction bytes to be inserted
+    pub fn reserve_ops(&mut self, additional: usize) {
+        self.ops.reserve(additional);
+    }
+
     /// Create a new dynamic label ID
     pub fn new_dynamic_label(&mut self) -> DynamicLabel {
         self.labels.new_dynamic_label()
@@ -416,6 +421,16 @@ impl<R: Relocation> VecAssembler<R> {
     /// Provides mutable access to the assemblers internal labels registry
     pub fn labels_mut(&mut self) -> &mut LabelRegistry {
         &mut self.labels
+    }
+
+    /// Provides access to the assemblers internal relocs registry
+    pub fn relocs(&self) -> &RelocRegistry<R> {
+        &self.relocs
+    }
+
+    /// Provides mutable access to the assemblers internal labels registry
+    pub fn relocs_mut(&mut self) -> &mut RelocRegistry<R> {
+        &mut self.relocs
     }
 
     /// Finalizes the `VecAssembler`, returning the resulting `Vec<u8>` containing all assembled data.


### PR DESCRIPTION
Exposing these interfaces gives a significant performance boost in some use cases, as per the numbers listed on https://github.com/near/wasmer/pull/142: as much as a 20-25% performance gain over the whole compiler on some benchmarks (that made me notice such an optimization would be useful), without even fine-tuning parameters.

The thing I'm least certain about is exposing the `relocs` and `relocs_mut` functions, but they seem to make sense to me given how the `labels` and `labels_mut` are already exposed.

What do you think about this? :)