### PR TITLE
Set min bitflags version to 1.1.0

### DIFF
--- a/plugin/Cargo.toml
+++ b/plugin/Cargo.toml
@@ -19,7 +19,7 @@ proc-macro = true
 
 [dependencies]
 lazy_static = "1"
-bitflags = "1"
+bitflags = "1.1.0"
 byteorder = "1"
 quote = "1"
 proc-macro-error = "1"


### PR DESCRIPTION
For all lower versions, dynasm 1.2.3 fails to compile.

This was discovered by trying to compile my project with `rm Cargo.lock && cargo +nightly build -Zminimal-versions` as suggested by https://twitter.com/jonhoo/status/1571290371124260865.