### PR TITLE
Clarification for MPL-2.0 license, include required Exhibit A

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,10 @@ repository = "https://github.com/CensoredUsername/dynasm-rs"
 readme = "README.md"
 keywords = ["jit", "dynasm", "dynasmrt", "dynasm-rs", "assembler"]
 license = "MPL-2.0"
+
+# Source Code Form notice (MPL-2.0 Exhibit A)
+# This notice applies to all source files within this workspace.
+#
+#   This Source Code Form is subject to the terms of the Mozilla Public
+#   License, v. 2.0. If a copy of the MPL was not distributed with this
+#   file, You can obtain one at http://mozilla.org/MPL/2.0/.


### PR DESCRIPTION
The dynasm and dynasmrt crates claim an MPL-2.0 license in the Cargo.toml and by including the LICENSE file, but the text of the license requires a specific declaration called the "source code form" to be made. Without this declaration, it's not possible to strictly comply with the license. This patch adds Exhibit A to the Cargo.toml where it should be unobtrusive but sufficient for license adherence.