### PR TITLE
add example crates in workspace.members

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,9 @@ members = [
     "runtime",
     "testing",
     "doc/insref",
+    "doc/examples/bf-interpreter",
+    "doc/examples/bf-jit",
+    "doc/examples/hello-world",
 ]
 
 [workspace.package]


### PR DESCRIPTION
add example crates into workspace members, or they cannot be by `cargo build` built directly. Error msg:
```
error: current package believes it's in a workspace when it's not:
current:   /Users/x/dynasm-rs/doc/examples/hello-world/Cargo.toml
workspace: /Users/x/dynasm-rs/Cargo.toml

this may be fixable by adding `doc/examples/hello-world` to the `workspace.members` array of the manifest located at: /Users/x/dynasm-rs/Cargo.toml
Alternatively, to keep it out of the workspace, add the package to the `workspace.exclude` array, or add an empty `[workspace]` table to the package's manifest.

```
