### PR TITLE
Add support for direct stores (MOVDIRI)

### DIFF
--- a/plugin/src/arch/x64/gen_opmap.rs
+++ b/plugin/src/arch/x64/gen_opmap.rs
@@ -1302,6 +1302,10 @@ Ops!(
     b"yomq"       , [0x0F, 0x12        ], X, PREF_F2, SSE3;
     b"yoyo"       , [0x0F, 0x12        ], X, PREF_F2, SSE3;
 ]
+"movdiri" = [
+    b"mdrd"       , [0x0F, 0x38, 0xF9  ], X, ENC_MR, DIRECTSTORES;
+    b"mqrq"       , [0x0F, 0x38, 0xF9  ], X, WITH_REXW | ENC_MR, DIRECTSTORES;
+]
 "movdq2q" = [
     b"xqyo"       , [0x0F, 0xD6        ], X, PREF_F2, SSE2;
 ]

--- a/plugin/src/arch/x64/x64data.rs
+++ b/plugin/src/arch/x64/x64data.rs
@@ -104,6 +104,7 @@ bitflags! {
         const PREFETCHWT1  = 0x0040_0000;
         const CYRIX        = 0x0080_0000;
         const AMD          = 0x0100_0000;
+        const DIRECTSTORES = 0x0200_0000;
     }
 }
 
@@ -139,6 +140,7 @@ impl Features {
             "prefetchwt1" => Some(Features::PREFETCHWT1),
             "cyrix" => Some(Features::CYRIX),
             "amd"   => Some(Features::AMD),
+            "directstores"   => Some(Features::DIRECTSTORES),
             _ => None
         }
     }
@@ -172,6 +174,7 @@ impl Display for Features {
         if self.contains(Features::PREFETCHWT1) { keys.push("prefetchwt1"); }
         if self.contains(Features::CYRIX) { keys.push("cyrix"); }
         if self.contains(Features::AMD)   { keys.push("amd"); }
+        if self.contains(Features::DIRECTSTORES)   { keys.push("directstores"); }
         for (i, k) in keys.into_iter().enumerate() {
             if i != 0 {
                 f.write_str(", ")?;
@@ -241,6 +244,7 @@ const SHA          : u32 = Features::SHA.bits;
 const PREFETCHWT1  : u32 = Features::PREFETCHWT1.bits;
 const CYRIX        : u32 = Features::CYRIX.bits;
 const AMD          : u32 = Features::AMD.bits;
+const DIRECTSTORES : u32 = Features::DIRECTSTORES.bits;
 
 
 lazy_static! {

--- a/testing/tests/directstores.rs
+++ b/testing/tests/directstores.rs
@@ -1,0 +1,6 @@
+#![allow(unused_imports)]
+
+use dynasmrt::dynasm;
+use dynasmrt::DynasmApi;
+
+include!("gen_x64/directstores.rs.gen");

--- a/testing/tests/gen_x64/directstores.rs.gen
+++ b/testing/tests/gen_x64/directstores.rs.gen
@@ -1,0 +1,135 @@
+
+#[test]
+fn enc_directstores_movdiri2154() {
+     let mut ops = dynasmrt::SimpleAssembler::new();
+     dynasm!(ops
+             ; .arch x64
+             ; movdiri QWORD [rax * 2 + rdx], rcx
+     );
+     let buf = ops.finalize();
+     let hex: Vec<String> = buf.iter().map(|x| format!("0x{:02X}", *x)).collect();
+     let hex: String = hex.join(", ");
+     assert_eq!(hex, "0x48, 0x0F, 0x38, 0xF9, 0x0C, 0x42", "movdiri QWORD [rax * 2 + rdx], rcx");
+}
+
+
+
+#[test]
+fn enc_directstores_movdiri2155() {
+     let mut ops = dynasmrt::SimpleAssembler::new();
+     dynasm!(ops
+             ; .arch x64
+             ; movdiri QWORD [rax], rcx
+     );
+     let buf = ops.finalize();
+     let hex: Vec<String> = buf.iter().map(|x| format!("0x{:02X}", *x)).collect();
+     let hex: String = hex.join(", ");
+     assert_eq!(hex, "0x48, 0x0F, 0x38, 0xF9, 0x08", "movdiri QWORD [rax], rcx");
+}
+
+
+
+#[test]
+fn enc_directstores_movdiri2156() {
+     let mut ops = dynasmrt::SimpleAssembler::new();
+     dynasm!(ops
+             ; .arch x64
+             ; movdiri QWORD [rax], rax
+     );
+     let buf = ops.finalize();
+     let hex: Vec<String> = buf.iter().map(|x| format!("0x{:02X}", *x)).collect();
+     let hex: String = hex.join(", ");
+     assert_eq!(hex, "0x48, 0x0F, 0x38, 0xF9, 0x00", "movdiri QWORD [rax], rax");
+}
+
+
+
+#[test]
+fn enc_directstores_movdiri2157() {
+     let mut ops = dynasmrt::SimpleAssembler::new();
+     dynasm!(ops
+             ; .arch x64
+             ; movdiri QWORD [rax + 16], rdx
+     );
+     let buf = ops.finalize();
+     let hex: Vec<String> = buf.iter().map(|x| format!("0x{:02X}", *x)).collect();
+     let hex: String = hex.join(", ");
+     assert_eq!(hex, "0x48, 0x0F, 0x38, 0xF9, 0x50, 0x10", "movdiri QWORD [rax + 16], rdx");
+}
+
+
+
+#[test]
+fn enc_directstores_movdiri2158() {
+     let mut ops = dynasmrt::SimpleAssembler::new();
+     dynasm!(ops
+             ; .arch x64
+             ; movdiri DWORD [rax + 16], ecx
+     );
+     let buf = ops.finalize();
+     let hex: Vec<String> = buf.iter().map(|x| format!("0x{:02X}", *x)).collect();
+     let hex: String = hex.join(", ");
+     assert_eq!(hex, "0x0F, 0x38, 0xF9, 0x48, 0x10", "movdiri DWORD [rax + 16], ecx");
+}
+
+
+
+#[test]
+fn enc_directstores_movdiri2159() {
+     let mut ops = dynasmrt::SimpleAssembler::new();
+     dynasm!(ops
+             ; .arch x64
+             ; movdiri DWORD [rax * 2 + rdx], edx
+     );
+     let buf = ops.finalize();
+     let hex: Vec<String> = buf.iter().map(|x| format!("0x{:02X}", *x)).collect();
+     let hex: String = hex.join(", ");
+     assert_eq!(hex, "0x0F, 0x38, 0xF9, 0x14, 0x42", "movdiri DWORD [rax * 2 + rdx], edx");
+}
+
+
+
+#[test]
+fn enc_directstores_movdiri2160() {
+     let mut ops = dynasmrt::SimpleAssembler::new();
+     dynasm!(ops
+             ; .arch x64
+             ; movdiri DWORD [rax + 16], eax
+     );
+     let buf = ops.finalize();
+     let hex: Vec<String> = buf.iter().map(|x| format!("0x{:02X}", *x)).collect();
+     let hex: String = hex.join(", ");
+     assert_eq!(hex, "0x0F, 0x38, 0xF9, 0x40, 0x10", "movdiri DWORD [rax + 16], eax");
+}
+
+
+
+#[test]
+fn enc_directstores_movdiri2161() {
+     let mut ops = dynasmrt::SimpleAssembler::new();
+     dynasm!(ops
+             ; .arch x64
+             ; movdiri DWORD [rax * 2 + rdx], ecx
+     );
+     let buf = ops.finalize();
+     let hex: Vec<String> = buf.iter().map(|x| format!("0x{:02X}", *x)).collect();
+     let hex: String = hex.join(", ");
+     assert_eq!(hex, "0x0F, 0x38, 0xF9, 0x0C, 0x42", "movdiri DWORD [rax * 2 + rdx], ecx");
+}
+
+
+
+#[test]
+fn enc_directstores_movdiri2162() {
+     let mut ops = dynasmrt::SimpleAssembler::new();
+     dynasm!(ops
+             ; .arch x64
+             ; movdiri DWORD [rax * 2 + rdx], eax
+     );
+     let buf = ops.finalize();
+     let hex: Vec<String> = buf.iter().map(|x| format!("0x{:02X}", *x)).collect();
+     let hex: String = hex.join(", ");
+     assert_eq!(hex, "0x0F, 0x38, 0xF9, 0x04, 0x42", "movdiri DWORD [rax * 2 + rdx], eax");
+}
+
+


### PR DESCRIPTION
Adds support for MOVDIRI instructions, and a feature flag for the associated "Direct Store" extension (in recent Intel microarchitectures).

This extension also includes the `MOVDIR64B` instruction, but I decided not to include it here because I have no particular use for it, and it wasn't immediately obvious how I should specify the encoding.