### PR TITLE
Fix "argument type/size mismatch" error.

### DIFF
--- a/plugin/src/arch/x64/debug.rs
+++ b/plugin/src/arch/x64/debug.rs
@@ -51,7 +51,7 @@ pub fn format_opdata(name: &str, data: &Opdata) -> Vec<String> {
     forms
 }
 
-static REGS: [&str; 16] = ["a",  "d",  "c",   "b",   "bp",  "sp",  "si",  "di",
+static REGS: [&str; 16] = ["a",  "c",  "d",   "b",   "sp",  "bp",  "si",  "di",
                                    "r8", "r9", "r10", "r11", "r12", "r13", "r14", "r15"];
 static SEGREGS: [&str; 6] = ["es", "cs", "ss", "ds", "fs", "gs"];
 


### PR DESCRIPTION
When incorrectly implementing an x86_64 instruction the compiler error message currently makes wrong suggestions about what the correc input should be. For example,

```
dynasm!(self.asm; shl Rq(Rq::RDX.code()), Rq::RAX.code()))
```

gives the following error:

```
error: 'shl': argument type/size mismatch, expected one of the following forms:
>>> shl reg/mem8, dl
>>> shl reg/mem8, imm8
>>> shl reg/mem64, dl
>>> shl reg/mem16, dl
...
```

However, `shl/shr` require the shift amount to be in the `CL` register, which is also how it is implement in dynasm-rs. This commit fixes the error message to report the correct register.