### PR TITLE
Switch from proc-macro-error to proc-macro-error2.

### DIFF
--- a/plugin/Cargo.toml
+++ b/plugin/Cargo.toml
@@ -22,7 +22,7 @@ lazy_static = "1"
 bitflags = "1.1.0"
 byteorder = "1"
 quote = "1"
-proc-macro-error = "1"
+proc-macro-error2 = "2.0"
 
 [dependencies.syn]
 version = "1"

--- a/plugin/src/arch/aarch64/compiler.rs
+++ b/plugin/src/arch/aarch64/compiler.rs
@@ -10,7 +10,7 @@ use crate::parse_helpers::{as_ident, as_number, as_float, as_signed_number};
 use syn::spanned::Spanned;
 use quote::{quote, quote_spanned};
 use proc_macro2::TokenStream;
-use proc_macro_error::emit_error;
+use proc_macro_error2::emit_error;
 
 pub(super) fn compile_instruction(ctx: &mut Context, data: MatchData) -> Result<(), Option<String>> {
     let mut cursor = 0usize;

--- a/plugin/src/arch/aarch64/matching.rs
+++ b/plugin/src/arch/aarch64/matching.rs
@@ -1,4 +1,4 @@
-use proc_macro_error::emit_error;
+use proc_macro_error2::emit_error;
 use proc_macro2::Span;
 
 use super::Context;

--- a/plugin/src/arch/aarch64/mod.rs
+++ b/plugin/src/arch/aarch64/mod.rs
@@ -1,5 +1,5 @@
 use syn::parse;
-use proc_macro_error::emit_error;
+use proc_macro_error2::emit_error;
 
 mod ast;
 mod parser;

--- a/plugin/src/arch/mod.rs
+++ b/plugin/src/arch/mod.rs
@@ -1,5 +1,5 @@
 use syn::parse;
-use proc_macro_error::emit_error;
+use proc_macro_error2::emit_error;
 
 use crate::common::{Size, Stmt, Jump};
 use crate::State;

--- a/plugin/src/arch/x64/compiler.rs
+++ b/plugin/src/arch/x64/compiler.rs
@@ -1,7 +1,7 @@
 use syn::spanned::Spanned;
 use proc_macro2::{Span, TokenTree};
 use quote::{quote_spanned};
-use proc_macro_error::emit_error;
+use proc_macro_error2::emit_error;
 
 use crate::common::{Stmt, Size, Jump, JumpKind, delimited};
 use crate::serialize;

--- a/plugin/src/arch/x64/mod.rs
+++ b/plugin/src/arch/x64/mod.rs
@@ -1,5 +1,5 @@
 use syn::parse;
-use proc_macro_error::emit_error;
+use proc_macro_error2::emit_error;
 
 mod ast;
 mod compiler;

--- a/plugin/src/arch/x64/parser.rs
+++ b/plugin/src/arch/x64/parser.rs
@@ -1,7 +1,7 @@
 use syn::{parse, Token};
 use syn::spanned::Spanned;
 use proc_macro2::Span;
-use proc_macro_error::emit_error;
+use proc_macro_error2::emit_error;
 
 use lazy_static::lazy_static;
 

--- a/plugin/src/directive.rs
+++ b/plugin/src/directive.rs
@@ -3,7 +3,7 @@ use std::collections::hash_map::Entry;
 use syn::parse;
 use syn::Token;
 use quote::quote;
-use proc_macro_error::emit_error;
+use proc_macro_error2::emit_error;
 
 use crate::common::{Stmt, Size, delimited};
 use crate::arch;

--- a/plugin/src/lib.rs
+++ b/plugin/src/lib.rs
@@ -15,7 +15,7 @@ use syn::parse;
 use syn::{Token, parse_macro_input};
 use proc_macro2::{TokenTree, TokenStream};
 use quote::quote;
-use proc_macro_error::proc_macro_error;
+use proc_macro_error2::proc_macro_error;
 
 use std::collections::HashMap;
 


### PR DESCRIPTION
This patch changes the dependency of proc-macro-error to be using proc-macro-error2 instead. We are updating this dependency due to cargo audit failures related to RUSTSEC-2024-0370[1] stating that proc-macro-error is now considered unmaintained.

[1]: https://rustsec.org/advisories/RUSTSEC-2024-0370