### PR TITLE
Add no_std support again

### DIFF
--- a/plugin/src/serialize.rs
+++ b/plugin/src/serialize.rs
@@ -251,7 +251,7 @@ pub fn expr_size_of_scale(ty: &syn::Path, value: &TokenTree, size: Size) -> Toke
     let size = size.as_literal();
 
     delimited(quote_spanned! { span=>
-        (::std::mem::size_of::<#ty>() as #size) * #value
+        (::core::mem::size_of::<#ty>() as #size) * #value
     })
 }
 
@@ -303,17 +303,17 @@ pub fn expr_offset_of(path: &syn::Path, attr: &syn::Ident, size: Size) -> TokenT
     let size = size.as_literal();
 
     delimited(quote_spanned! { span=>
-        ::std::mem::offset_of!(#path, #attr) as #size
+        ::core::mem::offset_of!(#path, #attr) as #size
     })
 }
 
-// returns std::mem::size_of<path>()
+// returns core::mem::size_of<path>()
 pub fn expr_size_of(path: &syn::Path) -> TokenTree {
     // generate a P<Expr> that returns the size of type at path
     let span = path.span();
 
     delimited(quote_spanned! { span=>
-        ::std::mem::size_of::<#path>()
+        ::core::mem::size_of::<#path>()
     })
 }
 

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -15,7 +15,12 @@ license.workspace = true
 
 
 [dependencies]
-memmap2 = "0.9.5"
-byteorder = "1.5.0"
-fnv = "1.0.7"
+memmap2 = { version = "0.9.5", optional = true }
+byteorder = { version = "1.5.0", default-features = false }
+fnv = { version = "1.0.7", default-features = false }
 dynasm = { version = "=3.0.1", path = "../plugin" }
+hashbrown = "0.15.1"
+
+[features]
+default = []
+std = ["fnv/std", "byteorder/std", "memmap2"]

--- a/runtime/src/aarch64.rs
+++ b/runtime/src/aarch64.rs
@@ -25,7 +25,7 @@
 use crate::Register;
 use crate::relocations::{Relocation, RelocationSize, RelocationKind, ImpossibleRelocation, fits_signed_bitfield};
 use byteorder::{ByteOrder, LittleEndian};
-use std::convert::TryFrom;
+use core::convert::TryFrom;
 
 /// Relocation implementation for the aarch64 architecture.
 #[derive(Debug, Clone)]
@@ -188,6 +188,7 @@ impl Relocation for Aarch64Relocation {
 }
 
 /// An aarch64 Assembler. This is aliased here for backwards compatability.
+#[cfg(feature = "std")]
 pub type Assembler = crate::Assembler<Aarch64Relocation>;
 /// An aarch64 AssemblyModifier. This is aliased here for backwards compatability.
 pub type AssemblyModifier<'a> = crate::Modifier<'a, Aarch64Relocation>;

--- a/runtime/src/cache_control.rs
+++ b/runtime/src/cache_control.rs
@@ -29,7 +29,7 @@ pub fn synchronize_icache(slice: &[u8]) {
 
 #[cfg(target_arch="aarch64")]
 mod aarch64 {
-    use std::arch::asm;
+    use core::arch::asm;
 
     /// return the cache line sizes as reported by the processor as a tuple of (dcache, icache)
     fn get_cacheline_sizes() -> (usize, usize) {

--- a/runtime/src/relocations.rs
+++ b/runtime/src/relocations.rs
@@ -2,7 +2,7 @@
 
 use byteorder::{ByteOrder, LittleEndian};
 
-use std::convert::TryFrom;
+use core::convert::TryFrom;
 
 /// Error returned when encoding a relocation failed
 #[derive(Debug)]

--- a/runtime/src/x64.rs
+++ b/runtime/src/x64.rs
@@ -22,7 +22,7 @@
 use crate::relocations::{Relocation, RelocationSize, RelocationKind, ImpossibleRelocation};
 use crate::Register;
 
-use std::hash::Hash;
+use core::hash::Hash;
 
 
 /// Relocation implementation for the x64 architecture.
@@ -61,6 +61,7 @@ impl Relocation for X64Relocation {
 }
 
 /// An x64 Assembler. This is aliased here for backwards compatability.
+#[cfg(feature = "std")]
 pub type Assembler = crate::Assembler<X64Relocation>;
 /// An x64 AssemblyModifier. This is aliased here for backwards compatability.
 pub type AssemblyModifier<'a> = crate::Modifier<'a, X64Relocation>;

--- a/runtime/src/x86.rs
+++ b/runtime/src/x86.rs
@@ -63,6 +63,7 @@ impl Relocation for X86Relocation {
 
 
 /// An x86 Assembler. This is aliased here for backwards compatability.
+#[cfg(feature = "std")]
 pub type Assembler = crate::Assembler<X86Relocation>;
 /// An x86 AssemblyModifier. This is aliased here for backwards compatability.
 pub type AssemblyModifier<'a> = crate::Modifier<'a, X86Relocation>;

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -9,3 +9,4 @@ itertools = "0.13.0"
 
 [dependencies.dynasmrt]
 path = "../runtime"
+features = ["std"]


### PR DESCRIPTION
This PR should add a minimal level of `no_std` support. This is needed in order for my shellcode generation project to work...Yes it is a little bit personal but I have my own restriction of not being able to use any std features to make the code as portable as possible...and that's the sole reason `no_std ` exist