### PR TITLE
Add support for the RDPRU instruction

### DIFF
--- a/plugin/src/arch/x64/gen_opmap.rs
+++ b/plugin/src/arch/x64/gen_opmap.rs
@@ -2296,6 +2296,9 @@ Ops!(
 "rdpmc" = [
     b""           , [0x0F, 0x33        ], X;
 ]
+"rdpru" = [
+    b""           , [0x0F, 0x01, 0xFD  ], X, AMD;
+]
 "rdrand" = [
     b"rq"         , [0x0F, 0xC7        ], 6, WITH_REXW;
 ]


### PR DESCRIPTION
Adds the encoding for the RDPRU ("Read Processor Register") instruction which is supported on recent AMD processors (starting with Zen 2).