### PR TITLE
Support opaque type (with Into<u8>) as dynamic register

### DIFF
--- a/doc/langref_aarch64.md
+++ b/doc/langref_aarch64.md
@@ -100,6 +100,7 @@ Dynamic Encoding  | `X`      | `W`      | `XSP`    | `WSP`    | `B`      | `H`  
              `31` | `xzr`    | `wzr`    | `sp`     | `wsp`    | `b31`    | `h31`    | `s31`    | `d31`    | `q31`    | `v31`    |
 
 When used statically, the notation simply matchers the given name in the table. When used dynamically, the syntax is similar to a function call: `X(reg_number)`, where reg_number is one of the given dynamic encodings listed in the table.
+Note the `reg_number` can be of an arbitrary type that implements `Into<u8>`.
 
 As aarch64 either uses scalar register 31 as the zero register `xzr` or the stack pointer register `sp`, two separate families of registers exist to encode this possible difference (as it can influence instruction variant choice).
 

--- a/doc/langref_riscv.md
+++ b/doc/langref_riscv.md
@@ -108,6 +108,7 @@ Dynamic Encoding  | `X`         | `W`            | `V`    |
              `31` | `x31/t6`    | `f31/ft`       | `v31`  |
 
 When used statically, the notation simply matchers the given name in the table. When used dynamically, the syntax is similar to a function call: `X(reg_number)`, where `reg_number` is one of the given dynamic encodings listed in the table.
+Note the `reg_number` can be of an arbitrary type that implements `Into<u8>`.
 
 Note that not all RISC-V instructions accept all registers. In particular, many instructions in the `C` instruction set extension don't support the `zero` register, or only support registers `x8-x15`. Attempting to use those will result in an error at compile time, or a panic at runtime.
 

--- a/plugin/src/arch/riscv/compiler.rs
+++ b/plugin/src/arch/riscv/compiler.rs
@@ -97,7 +97,7 @@ pub(super) fn compile_instruction(ctx: &mut Context, data: MatchData) -> Result<
                             Some(FlatArg::Register { reg: Register::Dynamic(_, ref expr), .. }) => {
                                 dynamics.push((0, quote_spanned!{ span=>
                                     {
-                                        let _dyn_reg: u8 = #expr;
+                                        let _dyn_reg: u8 = #expr.into();
                                         if _dyn_reg == #code {
                                             ::dynasmrt::riscv::invalid_register(#code);
                                         }
@@ -124,14 +124,17 @@ pub(super) fn compile_instruction(ctx: &mut Context, data: MatchData) -> Result<
             FlatArg::Register { span, reg: Register::Dynamic(_, ref expr) } => match *command {
                 Command::R(offset) => {
                     dynamics.push((offset, quote_spanned!{ span=>
-                        ((#expr & 0x1F) as u32)
+                        {
+                            let _dyn_reg: u8 = #expr.into();
+                            (_dyn_reg & 0x1F) as u32
+                        }
                     }));
                 },
                 Command::Reven(offset) => {
                     let invalid_reg_mask: u8 = if ctx.target.is_embedded() { 0xF0 } else { 0xE0 };
                     dynamics.push((offset, quote_spanned!{ span=>
                         {
-                            let _dyn_reg: u8 = #expr;
+                            let _dyn_reg: u8 = #expr.into();
                             if _dyn_reg & 0x1 != 0x0 || (_dyn_reg & #invalid_reg_mask) != 0 {
                                 ::dynasmrt::riscv::invalid_register(_dyn_reg);
                             }
@@ -143,7 +146,7 @@ pub(super) fn compile_instruction(ctx: &mut Context, data: MatchData) -> Result<
                     let invalid_reg_mask: u8 = if ctx.target.is_embedded() { 0xF0 } else { 0xE0 };
                     dynamics.push((offset, quote_spanned!{ span=>
                         {
-                            let _dyn_reg: u8 = #expr;
+                            let _dyn_reg: u8 = #expr.into();
                             if _dyn_reg == 0x0 || (_dyn_reg & #invalid_reg_mask) != 0 {
                                 ::dynasmrt::riscv::invalid_register(_dyn_reg);
                             }
@@ -155,7 +158,7 @@ pub(super) fn compile_instruction(ctx: &mut Context, data: MatchData) -> Result<
                     let invalid_reg_mask: u8 = if ctx.target.is_embedded() { 0xF0 } else { 0xE0 };
                     dynamics.push((offset, quote_spanned!{ span=>
                         {
-                            let _dyn_reg: u8 = #expr;
+                            let _dyn_reg: u8 = #expr.into();
                             if _dyn_reg == 0x0 || _dyn_reg == 0x2 || (_dyn_reg & #invalid_reg_mask) != 0 {
                                 ::dynasmrt::riscv::invalid_register(_dyn_reg);
                             }
@@ -167,7 +170,7 @@ pub(super) fn compile_instruction(ctx: &mut Context, data: MatchData) -> Result<
                     let invalid_reg_mask: u8 = if ctx.target.is_embedded() { 0xF0 } else { 0xE0 };
                     dynamics.push((offset, quote_spanned!{ span=>
                         {
-                            let _dyn_reg: u8 = #expr;
+                            let _dyn_reg: u8 = #expr.into();
                             if _dyn_reg & 0x18 != 0x8 || (_dyn_reg & #invalid_reg_mask) != 0 {
                                 ::dynasmrt::riscv::invalid_register(_dyn_reg);
                             }
@@ -179,7 +182,7 @@ pub(super) fn compile_instruction(ctx: &mut Context, data: MatchData) -> Result<
                     let invalid_reg_mask: u8 = if ctx.target.is_embedded() { 0xF0 } else { 0xE0 };
                     dynamics.push((offset, quote_spanned!{ span=>
                         {
-                            let _dyn_reg: u8 = #expr;
+                            let _dyn_reg: u8 = #expr.into();
                             if (1u32 << (_dyn_reg & 0x1F)) & 0x00_FC_03_00 == 0 || (_dyn_reg & #invalid_reg_mask) != 0 {
                                 ::dynasmrt::riscv::invalid_register(_dyn_reg);
                             }
@@ -193,7 +196,7 @@ pub(super) fn compile_instruction(ctx: &mut Context, data: MatchData) -> Result<
                         let invalid_reg_mask: u8 = if ctx.target.is_embedded() { 0xF0 } else { 0xE0 };
                         dynamics.push((offset, quote_spanned!{ span=>
                             {
-                                let _dyn_reg: u8 = #expr;
+                                let _dyn_reg: u8 = #expr.into();
                                 if (_dyn_reg == #code) || ((1u32 << (_dyn_reg & 0x1F)) & 0x00_FC_03_00 == 0) || (_dyn_reg & #invalid_reg_mask) != 0 {
                                     ::dynasmrt::riscv::invalid_register(_dyn_reg);
                                 }
@@ -205,8 +208,8 @@ pub(super) fn compile_instruction(ctx: &mut Context, data: MatchData) -> Result<
                         let invalid_reg_mask: u8 = if ctx.target.is_embedded() { 0xF0 } else { 0xE0 };
                         dynamics.push((offset, quote_spanned!{ span=>
                             {
-                                let _dyn_reg: u8 = #expr;
-                                let _dyn_reg_prev: u8 = #expr2;
+                                let _dyn_reg: u8 = #expr.into();
+                                let _dyn_reg_prev: u8 = #expr2.into();
                                 if (_dyn_reg == _dyn_reg_prev) || ((1u32 << (_dyn_reg & 0x1F)) & 0x00_FC_03_00 == 0) || (_dyn_reg & #invalid_reg_mask) != 0 {
                                     ::dynasmrt::riscv::invalid_register(_dyn_reg);
                                 }

--- a/testing/tests/riscv_dynamic.rs
+++ b/testing/tests/riscv_dynamic.rs
@@ -1,6 +1,8 @@
 use dynasmrt::dynasm;
 use dynasmrt::DynasmApi;
 
+use std::convert::Into;
+
 // confirms that static and dynamic encodings for immediates result in the same data
 // (regular tests confirmthis for registers)
 
@@ -176,4 +178,24 @@ fn offsets_range() {
     );
     let buf = ops.finalize();
     assert!(are_chunks_equal(&buf, 8), "offsets_range");
+}
+
+#[test]
+fn opaque_register_type() {
+    struct GPR {
+        register: u8
+    }
+
+    impl Into<u8> for GPR {
+        fn into(self) -> u8 {
+            self.register
+        }
+    }
+
+    let rs = GPR { register: 22 };
+    let mut ops = dynasmrt::SimpleAssembler::new();
+    dynasm!(ops
+        ; .arch riscv64
+        ; mv X(rs), X(12)
+    );
 }


### PR DESCRIPTION
As shown in the testcase, it's pretty handy to be able to construct an assembly snippet directly from a user-defined type (e.g. `GprRegister`). The only requirement is the type implements `Into<u8>`.