### PR TITLE
Fix x86-64 OUT missing 16-bit opcode prefix

### DIFF
--- a/plugin/src/arch/x64/gen_opmap.rs
+++ b/plugin/src/arch/x64/gen_opmap.rs
@@ -5547,7 +5547,7 @@ Ops!(
 
 "out"   = [
     b"ibAb"       , [0xE6            ], X;
-    b"ibAw"       , [0xE7            ], X;
+    b"ibAw"       , [0xE7            ], X, WORD_SIZE;
     b"ibAd"       , [0xE7            ], X;
     b"CwAb"       , [0xEE            ], X;
     b"CwAw"       , [0xEF            ], X, WORD_SIZE;


### PR DESCRIPTION
We discovered a bug that leads to a missing 16-bit prefix for the x86 `OUT` instruction when using 16-bit registers. As far as I can tell, no other instructions miss the prefix in their 16-bit version. So far I've tested `ADD`, `MOV`, `MUL`, `PUSH`, and `IN`.

Below is a minimal reproducer:
```
use dynasmrt::{DynasmApi, dynasm};

fn main() {
    let mut ops = dynasmrt::x64::Assembler::new().unwrap();
    dynasm!(ops
        ; .arch x64
        ; out 0xA_i8, ax
    );
    let code = ops.finalize().unwrap();
    println!("Generated Code:");
    for byte in code.into_iter() {
        print!("{:#03x?} ", byte);
    }
    println!("");
    assert_eq!(vec![0x66_u8, 0xe7_u8, 0xa_u8], code.to_vec());
}
```
The assert fails with the current state of `master`. This PR adds changes that modify the `opmap` to generate the missing prefix.

I also wanted to add a test for this, but didn't know where to place it, nor where to start (as this would mean to test a lot of instructions and I don't know if I can just add them to one of the files in testing) and if this is even necessary. I would be happy to hear about your opinion on this!