### PR TITLE
fix(aarch64): shift immhi bits of ADRP to account for immlo

### DIFF
--- a/plugin/src/arch/aarch64/compiler.rs
+++ b/plugin/src/arch/aarch64/compiler.rs
@@ -535,7 +535,7 @@ pub(super) fn compile_instruction(ctx: &mut Context, data: MatchData) -> Result<
                         let mask = bitmask(bits);
                         let half = -1i32 << (bits - 1);
                         if let Some((_, scaled)) = static_range_check(value, half, mask, 12)? {
-                            statics.push((5, scaled & 0x7FFFF));
+                            statics.push((5, (scaled >> 2u8) & 0x7FFFFu32));
                             statics.push((29, scaled & 3));
 
                         } else {


### PR DESCRIPTION
the immlo bits of the ADRP instruction on aarch64 must be shifted by 2, as the bottom two bits are stored in the immhi field. Similarly to how ADR works.

There is also blacklisted `adrp` within the testcase generator, I am not sure if it's because of this encoding issue or there was some other reason for it, probably worth a second look. (`/tools/aarch64_emit_tests.py`)
I couldn't get the test suite to regenerate on my mac easily, so I didn't check it.