### PR TITLE
feat(plugin): allow referencing output buffer in operands

### DIFF
--- a/plugin/src/serialize.rs
+++ b/plugin/src/serialize.rs
@@ -134,7 +134,12 @@ pub fn serialize(name: &TokenTree, stmts: Vec<Stmt>) -> TokenStream {
 
         // work around rustc giving code style warnings about unneeded parenthesis in method calls
         let mut args = args;
-        args.iter_mut().for_each(strip_parenthesis);
+        for (index, arg) in args.iter_mut().enumerate() {
+            strip_parenthesis(arg);
+            let argident = syn::Ident::new(&format!("a{}", index), arg.span());
+            output.extend(quote! { let #argident = #arg; });
+            *arg = argident.into();
+        }
 
         output.extend(quote! {
             #name . #method ( #( #args ),* ) ;


### PR DESCRIPTION
I am experimenting with an idea using dynasm (but not dynasmrt) that would make dynasm generate assembly into compile-time buffers. One of the things that I found myself wanting to implement is an ability to insert placeholders/relocations outside of what is supported natively by the dynasm syntax. My thought was that the most straightforward way to achieve this would have been:

```rust
dynasm!(custom_buffer
    ; mov rax, custom_buffer.placeholder()
)
```

but this currently fails to work for the sole reason that when expanded this code looks like this:

```rust
{
    buffer.extend(b"H\xc7\xc0");
    buffer.push_i32(buffer.placeholder());
};
```

and this will not work because `buffer` gets borrowed mutably twice. A straightforward solution is to evaluate user-provided expressions into a variable before doing anything dynasm specific with the buffer:

```rust
{
    buffer.extend(b"H\xc7\xc0");
    let a0 = buffer.placeholder();
    buffer.push_i32(a0);
};
```

This change is implemented here, although in the current iteration every argument is assigned to intermediate variables, even if not strictly necessary (e.g. the instruction byte buffer is also its own variable.)