### PR TITLE
feat: some support for `dynasm!` in a `const {}` context

### DIFF
--- a/plugin/Cargo.toml
+++ b/plugin/Cargo.toml
@@ -35,5 +35,9 @@ version = "1.0.106"
 dynasm_opmap = []
 dynasm_extract = []
 filelocal = []
+# Allow the expansions of `dynasm` macro use runtime-only functions, such as the automatic
+# `.into()` conversions of the dynamic registers. Disabling this featue allows `dynasm!` output to
+# be evaluated in `const {}` contexts.
+runtime_computations = []
 
-default = []
+default = ["runtime_computations"]

--- a/plugin/src/arch/aarch64/compiler.rs
+++ b/plugin/src/arch/aarch64/compiler.rs
@@ -4,7 +4,7 @@ use super::Context;
 use super::ast::{FlatArg, RegKind, RegId, Modifier};
 use super::encoding_helpers;
 
-use crate::common::{Stmt, Size, delimited, bitmask, RelocationEncoding};
+use crate::common::{Stmt, Size, delimited, bitmask, RelocationEncoding, maybe_into};
 use crate::parse_helpers::{as_ident, as_unsigned_number, as_float, as_signed_number};
 
 use syn::spanned::Spanned;
@@ -90,28 +90,28 @@ pub(super) fn compile_instruction(ctx: &mut Context, data: MatchData) -> Result<
             FlatArg::Direct { span, reg: RegKind::Dynamic(_, ref expr) } => match *command {
                 Command::R(offset)
                 | Command::RNoZr(offset) => {
-                    let expr = delimited(expr);
+                    let expr = maybe_into(expr);
                     dynamics.push((offset, quote_spanned!{ span=>
                         {
-                            let _dyn_reg: u8 = #expr.into();
+                            let _dyn_reg: u8 = #expr;
                             _dyn_reg & 0x1F
                         }
                     }));
                 },
                 Command::REven(offset) => {
-                    let expr = delimited(expr);
+                    let expr = maybe_into(expr);
                     dynamics.push((offset, quote_spanned!{ span=>
                         {
-                            let _dyn_reg: u8 = #expr.into();
+                            let _dyn_reg: u8 = #expr;
                             _dyn_reg & 0x1E
                         }
                     }));
                 },
                 Command::R4(offset) => {
-                    let expr = delimited(expr);
+                    let expr = maybe_into(expr);
                     dynamics.push((offset, quote_spanned!{ span=>
                         {
-                            let _dyn_reg: u8 = #expr.into();
+                            let _dyn_reg: u8 = #expr;
                             _dyn_reg & 0xF
                         }
                     }));

--- a/plugin/src/arch/riscv/compiler.rs
+++ b/plugin/src/arch/riscv/compiler.rs
@@ -8,7 +8,7 @@ use proc_macro2::{TokenStream, Span, Literal};
 use proc_macro_error3::emit_error;
 
 use crate::parse_helpers::{as_signed_number, as_ident, as_float};
-use crate::common::{Stmt, Size, delimited, bitmask, bitmask64, RelocationEncoding};
+use crate::common::{Stmt, Size, delimited, bitmask, bitmask64, maybe_into, RelocationEncoding};
 
 /// Compile a single instruction. Input is taken from `data`, containing both the arguments
 /// and the encoding template and commands.
@@ -95,10 +95,10 @@ pub(super) fn compile_instruction(ctx: &mut Context, data: MatchData) -> Result<
                                 }
                             },
                             Some(FlatArg::Register { reg: Register::Dynamic(_, ref expr), .. }) => {
-                                let expr = delimited(expr);
+                                let expr = maybe_into(expr);
                                 dynamics.push((0, quote_spanned!{ span=>
                                     {
-                                        let _dyn_reg: u8 = #expr.into();
+                                        let _dyn_reg: u8 = #expr;
                                         if _dyn_reg == #code {
                                             ::dynasmrt::riscv::invalid_register(#code);
                                         }
@@ -124,20 +124,20 @@ pub(super) fn compile_instruction(ctx: &mut Context, data: MatchData) -> Result<
 
             FlatArg::Register { span, reg: Register::Dynamic(_, ref expr) } => match *command {
                 Command::R(offset) => {
-                    let expr = delimited(expr);
+                    let expr = maybe_into(expr);
                     dynamics.push((offset, quote_spanned!{ span=>
                         {
-                            let _dyn_reg: u8 = #expr.into();
+                            let _dyn_reg: u8 = #expr;
                             (_dyn_reg & 0x1F) as u32
                         }
                     }));
                 },
                 Command::Reven(offset) => {
                     let invalid_reg_mask: u8 = if ctx.target.is_embedded() { 0xF0 } else { 0xE0 };
-                    let expr = delimited(expr);
+                    let expr = maybe_into(expr);
                     dynamics.push((offset, quote_spanned!{ span=>
                         {
-                            let _dyn_reg: u8 = #expr.into();
+                            let _dyn_reg: u8 = #expr;
                             if _dyn_reg & 0x1 != 0x0 || (_dyn_reg & #invalid_reg_mask) != 0 {
                                 ::dynasmrt::riscv::invalid_register(_dyn_reg);
                             }
@@ -147,10 +147,10 @@ pub(super) fn compile_instruction(ctx: &mut Context, data: MatchData) -> Result<
                 },
                 Command::Rno0(offset) => {
                     let invalid_reg_mask: u8 = if ctx.target.is_embedded() { 0xF0 } else { 0xE0 };
-                    let expr = delimited(expr);
+                    let expr = maybe_into(expr);
                     dynamics.push((offset, quote_spanned!{ span=>
                         {
-                            let _dyn_reg: u8 = #expr.into();
+                            let _dyn_reg: u8 = #expr;
                             if _dyn_reg == 0x0 || (_dyn_reg & #invalid_reg_mask) != 0 {
                                 ::dynasmrt::riscv::invalid_register(_dyn_reg);
                             }
@@ -160,10 +160,10 @@ pub(super) fn compile_instruction(ctx: &mut Context, data: MatchData) -> Result<
                 },
                 Command::Rno02(offset) => {
                     let invalid_reg_mask: u8 = if ctx.target.is_embedded() { 0xF0 } else { 0xE0 };
-                    let expr = delimited(expr);
+                    let expr = maybe_into(expr);
                     dynamics.push((offset, quote_spanned!{ span=>
                         {
-                            let _dyn_reg: u8 = #expr.into();
+                            let _dyn_reg: u8 = #expr;
                             if _dyn_reg == 0x0 || _dyn_reg == 0x2 || (_dyn_reg & #invalid_reg_mask) != 0 {
                                 ::dynasmrt::riscv::invalid_register(_dyn_reg);
                             }
@@ -173,10 +173,10 @@ pub(super) fn compile_instruction(ctx: &mut Context, data: MatchData) -> Result<
                 },
                 Command::Rpop(offset) => {
                     let invalid_reg_mask: u8 = if ctx.target.is_embedded() { 0xF0 } else { 0xE0 };
-                    let expr = delimited(expr);
+                    let expr = maybe_into(expr);
                     dynamics.push((offset, quote_spanned!{ span=>
                         {
-                            let _dyn_reg: u8 = #expr.into();
+                            let _dyn_reg: u8 = #expr;
                             if _dyn_reg & 0x18 != 0x8 || (_dyn_reg & #invalid_reg_mask) != 0 {
                                 ::dynasmrt::riscv::invalid_register(_dyn_reg);
                             }
@@ -186,10 +186,10 @@ pub(super) fn compile_instruction(ctx: &mut Context, data: MatchData) -> Result<
                 },
                 Command::Rpops(offset) => {
                     let invalid_reg_mask: u8 = if ctx.target.is_embedded() { 0xF0 } else { 0xE0 };
-                    let expr = delimited(expr);
+                    let expr = maybe_into(expr);
                     dynamics.push((offset, quote_spanned!{ span=>
                         {
-                            let _dyn_reg: u8 = #expr.into();
+                            let _dyn_reg: u8 = #expr;
                             if (1u32 << (_dyn_reg & 0x1F)) & 0x00_FC_03_00 == 0 || (_dyn_reg & #invalid_reg_mask) != 0 {
                                 ::dynasmrt::riscv::invalid_register(_dyn_reg);
                             }
@@ -201,10 +201,10 @@ pub(super) fn compile_instruction(ctx: &mut Context, data: MatchData) -> Result<
                     Some(FlatArg::Register { reg: Register::Static(id2), .. } ) => {
                         let code: u8 = id2.code();
                         let invalid_reg_mask: u8 = if ctx.target.is_embedded() { 0xF0 } else { 0xE0 };
-                        let expr = delimited(expr);
+                        let expr = maybe_into(expr);
                         dynamics.push((offset, quote_spanned!{ span=>
                             {
-                                let _dyn_reg: u8 = #expr.into();
+                                let _dyn_reg: u8 = #expr;
                                 if (_dyn_reg == #code) || ((1u32 << (_dyn_reg & 0x1F)) & 0x00_FC_03_00 == 0) || (_dyn_reg & #invalid_reg_mask) != 0 {
                                     ::dynasmrt::riscv::invalid_register(_dyn_reg);
                                 }
@@ -214,12 +214,12 @@ pub(super) fn compile_instruction(ctx: &mut Context, data: MatchData) -> Result<
                     },
                     Some(FlatArg::Register { reg: Register::Dynamic(_, ref expr2), .. }) => {
                         let invalid_reg_mask: u8 = if ctx.target.is_embedded() { 0xF0 } else { 0xE0 };
-                        let expr = delimited(expr);
-                        let expr2 = delimited(expr2);
+                        let expr = maybe_into(expr);
+                        let expr2 = maybe_into(expr2);
                         dynamics.push((offset, quote_spanned!{ span=>
                             {
-                                let _dyn_reg: u8 = #expr.into();
-                                let _dyn_reg_prev: u8 = #expr2.into();
+                                let _dyn_reg: u8 = #expr;
+                                let _dyn_reg_prev: u8 = #expr2;
                                 if (_dyn_reg == _dyn_reg_prev) || ((1u32 << (_dyn_reg & 0x1F)) & 0x00_FC_03_00 == 0) || (_dyn_reg & #invalid_reg_mask) != 0 {
                                     ::dynasmrt::riscv::invalid_register(_dyn_reg);
                                 }
@@ -276,7 +276,7 @@ pub(super) fn compile_instruction(ctx: &mut Context, data: MatchData) -> Result<
                 // This practically means we just don't have to encode anything.
                 Command::UImm(_, _)
                 | Command::SImm(_, _)
-                | Command::BitRange(_, _, _) 
+                | Command::BitRange(_, _, _)
                 | Command::Next => (),
                 _ => panic!("Invalid argument processor")
             },

--- a/plugin/src/arch/x64/compiler.rs
+++ b/plugin/src/arch/x64/compiler.rs
@@ -3,7 +3,7 @@ use proc_macro2::{Span, Literal};
 use quote::{quote_spanned, quote};
 use proc_macro_error3::emit_error;
 
-use crate::common::{Stmt, Size, JumpTarget, JumpTargetKind, RelocationEncoding, delimited, strip_parenthesis};
+use crate::common::{Stmt, Size, JumpTarget, JumpTargetKind, RelocationEncoding, delimited, strip_parenthesis, maybe_into};
 use crate::serialize;
 
 use super::{Context, X86Mode};
@@ -240,9 +240,10 @@ pub(super) fn compile_instruction(ctx: &mut Context, instruction: Instruction, a
 
         buffer.push(match rm_k {
             RegKind::Dynamic(_, expr) => {
+                let expr = maybe_into(expr);
                 Stmt::ExprUnsigned(delimited(quote_spanned!{ expr.span()=>
                     {
-                        let _dyn_reg: u8 = #expr.into();
+                        let _dyn_reg: u8 = #expr;
                         (_dyn_reg & 7) + #last
                     }
                 }), Size::BYTE)
@@ -446,7 +447,7 @@ pub(super) fn compile_instruction(ctx: &mut Context, instruction: Instruction, a
     // register in immediate argument
     if let Some(SizedArg::Direct {reg: ireg, ..}) = ireg {
         let ireg = ireg.kind;
-        
+
         let immediate = if !args.is_empty() {
             if let SizedArg::Immediate {value, size: Size::BYTE} = args.remove(0) {
                 Some(delimited(value))
@@ -459,17 +460,19 @@ pub(super) fn compile_instruction(ctx: &mut Context, instruction: Instruction, a
 
         let expr = match (ireg, immediate) {
             (RegKind::Dynamic(_, expr), None) => {
-                delimited(quote_spanned!{ expr.span()=> 
+                let expr = maybe_into(expr);
+                delimited(quote_spanned!{ expr.span()=>
                     {
-                        let _dyn_reg: u8 = #expr.into();
+                        let _dyn_reg: u8 = #expr;
                         ((_dyn_reg & 0xF) << 4)
                     }
                 })
             },
             (RegKind::Dynamic(_, expr), Some(imm)) => {
-                delimited(quote_spanned!{ expr.span()=> 
+                let expr = maybe_into(expr);
+                delimited(quote_spanned!{ expr.span()=>
                     {
-                        let _dyn_reg: u8 = #expr.into();
+                        let _dyn_reg: u8 = #expr;
                         ((_dyn_reg & 0xF) << 4) | (#imm & 0xF)
                     }
                 })
@@ -1526,27 +1529,27 @@ fn compile_rex(buffer: &mut Vec<Stmt>, rex_w: bool, reg: &Option<SizedArg>, rm: 
     let mut dyn_items = Vec::new();
 
     if let RegKind::Dynamic(_, expr) = reg_k {
-        let expr = delimited(expr);
+        let expr = maybe_into(expr);
         dyn_regs.push(quote_spanned! { expr.span()=>
-            let _dyn_reg: u8 = #expr.into();
+            let _dyn_reg: u8 = #expr;
         });
         dyn_items.push(quote_spanned! { expr.span()=>
             ((_dyn_reg & 8) >> 1)
         });
     }
     if let RegKind::Dynamic(_, expr) = index_k {
-        let expr = delimited(expr);
+        let expr = maybe_into(expr);
         dyn_regs.push(quote_spanned! { expr.span()=>
-            let _dyn_index: u8 = #expr.into();
+            let _dyn_index: u8 = #expr;
         });
         dyn_items.push(quote_spanned! { expr.span()=>
             ((_dyn_index & 8) >> 2)
         });
     }
     if let RegKind::Dynamic(_, expr) = base_k {
-        let expr = delimited(expr);
+        let expr = maybe_into(expr);
         dyn_regs.push(quote_spanned! { expr.span()=>
-            let _dyn_base: u8 = #expr.into();
+            let _dyn_base: u8 = #expr;
         });
         dyn_items.push(quote_spanned! { expr.span()=>
             ((_dyn_base & 8) >> 3)
@@ -1620,18 +1623,18 @@ rm: &Option<SizedArg>, map_sel: u8, rex_w: bool, vvvv: &Option<SizedArg>, vex_l:
         let mut dyn_items = Vec::new();
 
         if let RegKind::Dynamic(_, expr) = reg_k {
-            let expr = delimited(expr);
+            let expr = maybe_into(expr);
             dyn_regs.push(quote_spanned! { expr.span()=>
-                let _dyn_reg: u8 = #expr.into();
+                let _dyn_reg: u8 = #expr;
             });
             dyn_items.push(quote_spanned! { expr.span()=>
                 !((_dyn_reg & 8) << 4)
             });
         }
         if let RegKind::Dynamic(_, expr) = vvvv_k {
-            let expr = delimited(expr);
+            let expr = maybe_into(expr);
             dyn_regs.push(quote_spanned! { expr.span()=>
-                let _dyn_vvvv: u8 = #expr.into();
+                let _dyn_vvvv: u8 = #expr;
             });
             dyn_items.push(quote_spanned! { expr.span()=>
                 !((_dyn_vvvv & 0xF) << 3)
@@ -1655,27 +1658,27 @@ rm: &Option<SizedArg>, map_sel: u8, rex_w: bool, vvvv: &Option<SizedArg>, vex_l:
         let mut dyn_items = Vec::new();
 
         if let RegKind::Dynamic(_, expr) = reg_k {
-            let expr = delimited(expr);
+            let expr = maybe_into(expr);
             dyn_regs.push(quote_spanned! { expr.span()=>
-                let _dyn_reg: u8 = #expr.into();
+                let _dyn_reg: u8 = #expr;
             });
             dyn_items.push(quote_spanned! { expr.span()=>
                 !((_dyn_reg & 8) << 4)
             });
         }
         if let RegKind::Dynamic(_, expr) = index_k {
-            let expr = delimited(expr);
+            let expr = maybe_into(expr);
             dyn_regs.push(quote_spanned! { expr.span()=>
-                let _dyn_index: u8 = #expr.into();
+                let _dyn_index: u8 = #expr;
             });
             dyn_items.push(quote_spanned! { expr.span()=>
                 !((_dyn_index & 8) << 3)
             });
         }
         if let RegKind::Dynamic(_, expr) = base_k {
-            let expr = delimited(expr);
+            let expr = maybe_into(expr);
             dyn_regs.push(quote_spanned! { expr.span()=>
-                let _dyn_base: u8 = #expr.into();
+                let _dyn_base: u8 = #expr;
             });
             dyn_items.push(quote_spanned! { expr.span()=>
                 !((_dyn_base & 8) << 2)
@@ -1695,10 +1698,10 @@ rm: &Option<SizedArg>, map_sel: u8, rex_w: bool, vvvv: &Option<SizedArg>, vex_l:
 
     if let RegKind::Dynamic(_, expr) = vvvv_k {
         let byte2 = Literal::u8_suffixed(byte2);
-        let expr = delimited(expr);
+        let expr = maybe_into(expr);
         buffer.push(Stmt::ExprUnsigned(delimited(quote! {
             {
-                let _dyn_vvvv: u8 = #expr.into();
+                let _dyn_vvvv: u8 = #expr;
                 #byte2 & !((_dyn_vvvv & 0xF) << 3)
             }
         }), Size::BYTE));
@@ -1721,18 +1724,18 @@ fn compile_modrm_sib(buffer: &mut Vec<Stmt>, mode: u8, reg1: RegKind, reg2: RegK
     let mut dyn_items = Vec::new();
 
     if let RegKind::Dynamic(_, expr) = reg1 {
-        let expr = delimited(expr);
+        let expr = maybe_into(expr);
         dyn_regs.push(quote_spanned! { expr.span()=>
-            let _dyn_reg1: u8 = #expr.into();
+            let _dyn_reg1: u8 = #expr;
         });
         dyn_items.push(quote_spanned! { expr.span()=>
             ((_dyn_reg1 & 7) << 3)
         });
     }
     if let RegKind::Dynamic(_, expr) = reg2 {
-        let expr = delimited(expr);
+        let expr = maybe_into(expr);
         dyn_regs.push(quote_spanned! { expr.span()=>
-            let _dyn_reg2: u8 = #expr.into();
+            let _dyn_reg2: u8 = #expr;
         });
         dyn_items.push(quote_spanned! { expr.span()=>
             (_dyn_reg2 & 7)
@@ -1756,18 +1759,18 @@ fn compile_sib_dynscale(buffer: &mut Vec<Stmt>, scale: u8, scale_expr: syn::Expr
     let mut dyn_items = Vec::new();
 
     if let RegKind::Dynamic(_, expr) = reg1 {
-        let expr = delimited(expr);
+        let expr = maybe_into(expr);
         dyn_regs.push(quote_spanned! { expr.span()=>
-            let _dyn_reg1: u8 = #expr.into();
+            let _dyn_reg1: u8 = #expr;
         });
         dyn_items.push(quote_spanned! { expr.span()=>
             ((_dyn_reg1 & 7) << 3)
         });
     }
     if let RegKind::Dynamic(_, expr) = reg2 {
-        let expr = delimited(expr);
+        let expr = maybe_into(expr);
         dyn_regs.push(quote_spanned! { expr.span()=>
-            let _dyn_reg2: u8 = #expr.into();
+            let _dyn_reg2: u8 = #expr;
         });
         dyn_items.push(quote_spanned! { expr.span()=>
             (_dyn_reg2 & 7)
@@ -1776,7 +1779,7 @@ fn compile_sib_dynscale(buffer: &mut Vec<Stmt>, scale: u8, scale_expr: syn::Expr
 
     let scale_expr = delimited(scale_expr);
     let scale = Literal::u8_unsuffixed(scale);
-    dyn_regs.push(quote_spanned!{ scale_expr.span()=> 
+    dyn_regs.push(quote_spanned!{ scale_expr.span()=>
         let _dyn_scale = match #scale_expr * #scale {
             8 => 3,
             4 => 2,

--- a/plugin/src/common.rs
+++ b/plugin/src/common.rs
@@ -390,3 +390,18 @@ pub fn bitmask(scale: u8) -> u32 {
 pub fn bitmask64(scale: u8) -> u64 {
     1u64.checked_shl(u32::from(scale)).unwrap_or(0).wrapping_sub(1)
 }
+
+/// Wrap the provided expression in an `Into::into` call.
+///
+/// This is only done when the crate is built with the operand_conversions feature enabled.
+#[cfg(feature = "runtime_computations")]
+pub fn maybe_into(expr: impl quote::ToTokens) -> proc_macro2::TokenStream {
+    quote::quote_spanned! { expr.span()=>
+        Into::into(#expr)
+    }
+}
+
+#[cfg(not(feature = "runtime_computations"))]
+pub fn maybe_into(expr: impl quote::ToTokens) -> proc_macro2::TokenStream {
+    quote::ToTokens::into_token_stream(delimited(expr))
+}

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -18,4 +18,8 @@ license.workspace = true
 memmap2 = "0.9.9"
 byteorder = "1.5.0"
 fnv = "1.0.7"
-dynasm = { version = "=5.1.0", path = "../plugin" }
+dynasm = { version = "=5.1.0", path = "../plugin", default-features = false }
+
+[features]
+default = ["runtime_computations"]
+runtime_computations = ["dynasm/runtime_computations"]

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -9,3 +9,8 @@ itertools = "0.14.0"
 
 [dependencies.dynasmrt]
 path = "../runtime"
+default-features = false
+
+[features]
+default = ["runtime_computations"]
+runtime_computations = ["dynasmrt/runtime_computations"]

--- a/testing/tests/aarch64_complex.rs
+++ b/testing/tests/aarch64_complex.rs
@@ -136,6 +136,7 @@ fn complex() {
     println!("");
 }
 
+#[cfg(feature = "runtime_computations")]
 #[test]
 fn opaque_register_type() {
     struct Gpr {

--- a/testing/tests/bugreports.rs
+++ b/testing/tests/bugreports.rs
@@ -120,6 +120,7 @@ fn bugreport_6() {
 }
 
 
+#[cfg(feature = "runtime_computations")]
 #[test]
 fn rustc_does_not_properly_respect_macro_expr_grouping_for_precedence() {
     // the issue here is that code for emitting dynamic registers ends up emitting code like this

--- a/testing/tests/const_dynasm.rs
+++ b/testing/tests/const_dynasm.rs
@@ -1,0 +1,152 @@
+#![cfg(not(feature = "runtime_computations"))]
+#![allow(dead_code)]
+
+#[derive(Copy, Clone)]
+struct ConstAssembler<const SIZE: usize> {
+    buffer: [u8; SIZE],
+    bytes: usize,
+}
+
+impl<const SIZE: usize> ConstAssembler<SIZE> {
+    pub const fn new() -> Self {
+        Self {
+            buffer: [0; SIZE],
+            bytes: 0,
+        }
+    }
+
+    pub const fn extend(&mut self, buffer: &[u8]) {
+        let mut i = 0;
+        while i < buffer.len() {
+            self.buffer[self.bytes] = buffer[i];
+            self.bytes += 1;
+            i += 1;
+        }
+    }
+
+    pub const fn offset(&self) -> usize {
+        self.bytes
+    }
+
+    pub const fn push(&mut self, byte: u8) {
+        self.buffer[self.bytes] = byte;
+        self.bytes += 1;
+    }
+
+    pub const fn align(&mut self, alignment: usize, with: u8) {
+        let mut to_add = self.bytes - (self.bytes % alignment);
+        while to_add != 0 {
+            self.buffer[self.bytes] = with;
+            self.bytes += 1;
+            to_add -= 1;
+        }
+    }
+
+    pub const fn push_i8(&mut self, value: i8) {
+        self.push(value as u8);
+    }
+
+    pub const fn push_i16(&mut self, value: i16) {
+        self.extend(&i16::to_le_bytes(value));
+    }
+
+    pub const fn push_i32(&mut self, value: i32) {
+        self.extend(&i32::to_le_bytes(value));
+    }
+
+    pub const fn push_i64(&mut self, value: i64) {
+        self.extend(&i64::to_le_bytes(value));
+    }
+
+    pub const fn push_u16(&mut self, value: u16) {
+        self.extend(&u16::to_le_bytes(value));
+    }
+
+    pub const fn push_u32(&mut self, value: u32) {
+        self.extend(&u32::to_le_bytes(value));
+    }
+
+    pub const fn push_u64(&mut self, value: u64) {
+        self.extend(&u64::to_le_bytes(value));
+    }
+
+    pub const fn runtime_error(&self, msg: &'static str) {
+        panic!("{}", msg);
+    }
+
+    pub const fn local_label(&mut self, _name: &'static str) {}
+    pub const fn forward_reloc(
+        &mut self,
+        _name: &'static str,
+        _target_offset: isize,
+        _field_offset: u8,
+        _ref_offset: u8,
+        _kind: u8,
+    ) {
+    }
+    pub const fn backward_reloc(
+        &mut self,
+        _name: &'static str,
+        _target_offset: isize,
+        _field_offset: u8,
+        _ref_offset: u8,
+        _kind: u8,
+    ) {
+    }
+}
+
+#[test]
+fn x64_const_dynasm() {
+    const {
+        let mut out = ConstAssembler::<64>::new();
+        let reg = 1;
+        let imm = 3;
+        dynasmrt::dynasm!(out
+            ; .arch x64
+
+            ;   jmp >start
+            ; start:
+            ;   syscall
+            ;   add rax, Rq(1)
+            ;   add Rq(reg), [ BYTE 32 + Rq(reg) + Rq(reg) * 4 ]
+            ;   add rax, BYTE imm
+            ;   ja <start
+        );
+    };
+}
+
+#[test]
+fn riscv_const_dynasm() {
+    const {
+        let mut out = ConstAssembler::<64>::new();
+        let reg = 1;
+        dynasmrt::dynasm!(out
+            ; .arch riscv64
+
+            ;   j >start
+            ; start:
+            ;   ecall
+            ;   add x10, x10, X(1)
+            ;   add X(reg), X(reg), X(reg)
+            ;   bgtu x10, x11, <start
+        );
+    };
+}
+
+#[test]
+fn aarch64_const_dynasm() {
+    const {
+        let mut out = ConstAssembler::<64>::new();
+        let reg = 1;
+        dynasmrt::dynasm!(out
+            ; .arch aarch64
+
+            ;   b >start
+            ; start:
+            ;   svc #0
+            ;   add x0, x0, X(1)
+            ;   add X(reg), X(reg), X(reg), lsl #2
+            ;   b.hi <start
+        );
+    };
+}

--- a/testing/tests/riscv_dynamic.rs
+++ b/testing/tests/riscv_dynamic.rs
@@ -180,6 +180,7 @@ fn offsets_range() {
     assert!(are_chunks_equal(&buf, 8), "offsets_range");
 }
 
+#[cfg(feature = "runtime_computations")]
 #[test]
 fn opaque_register_type() {
     struct Gpr {


### PR DESCRIPTION
dynasm currently generates a small amount of code that has to be executed at runtime, which then makes it impossible to generate and store into e.g. a static table some snippets of assembly at compile time.

I have added a test of how such const-time JIT might look in practice if we were to make some of the relevant runtime-only features the macro has. The most major of them was the `Into::<u8>::into` use, which for const-context was removed altogether.

There is another one that I've seen but haven't addressed yet in this commit: the size checks for dynamic immediates call into non-const panic functions in dynasmrt. I have thoughts, but lets see if we want to have anything of this sort at all in the first place before I spend more time on this.